### PR TITLE
Fix example byte string contents for various Array types

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -979,7 +979,7 @@ The bytes_value of the Sparkplug Metric must be: [0x15, 0xCD, 0x5B, 0x07, 0xB1, 
 *** Int8Array as an array of packed little endian int8 bytes
 *** Google Protocol Buffer Type: bytes
 *** Sparkplug enum value: 22
-*** Example (Decimal to Metric bytes_value): [-23, 123] -> [0xEF, 0x7B]
+*** Example (Decimal to Metric bytes_value): [-23, 123] -> [0xE9, 0x7B]
 ** _Int16Array_
 *** Int16Array as an array of packed little endian int16 bytes
 *** Google Protocol Buffer Type: bytes
@@ -1019,12 +1019,12 @@ The bytes_value of the Sparkplug Metric must be: [0x15, 0xCD, 0x5B, 0x07, 0xB1, 
 *** FloatArray as an array of packed little endian 32-bit float bytes
 *** Google Protocol Buffer Type: bytes
 *** Sparkplug enum value: 30
-*** Example (Decimal to Metric bytes_value): [1.23, 89.341] -> [0x3F, 0x9D, 0x70, 0xA4, 0x42, 0xB2, 0xAE, 0x98]
+*** Example (Decimal to Metric bytes_value): [1.23, 89.341] -> [0xA4, 0x70, 0x9D, 0x3F, 0x98, 0xAE, 0xB2, 0x42]
 ** _DoubleArray_
 *** DoubleArray as an array of packed little endian 64-bit float bytes
 *** Google Protocol Buffer Type: bytes
 *** Sparkplug enum value: 31
-*** Example (Decimal to Metric bytes_value): [12.354213, 1022.9123213] -> [0x40, 0x28, 0xB5, 0x5B, 0x68, 0x05, 0xA2, 0xD7, 0x40, 0x8F, 0xF7, 0x4C, 0x6F, 0x1C, 0x17, 0x8E]
+*** Example (Decimal to Metric bytes_value): [12.354213, 1022.9123213] -> [0xD7, 0xA2, 0x05, 0x68, 0x5B, 0xB5, 0x28, 0x40, 0x8E, 0x17, 0x1C, 0x6F, 0x4C, 0xF7, 0x8F, 0x40]
 ** _BooleanArray_
 *** BooleanArray as an array of bit-packed bytes preceeded by a 4-byte integer that represents the
 total number of boolean values
@@ -1043,7 +1043,7 @@ ends on a byte boundary.
 value representing the number of milliseconds since epoch in UTC
 *** Google Protocol Buffer Type: bytes
 *** Sparkplug enum value: 34
-*** Example (DateTime array -> ms since epoch -> Metric bytes_value): ['Wednesday, October 21, 2009 5:27:55.335 AM', 'Friday, June 24, 2022 9:57:55 PM'] -> [1256102875335, 1656107875000] -> [0xC7, 0xD0, 0x90, 0x75, 0x24, 0x01, 0xB8, 0xBA, 0xB8, 0x97, 0x81, 0x01]
+*** Example (DateTime array -> ms since epoch -> Metric bytes_value): ['Wednesday, October 21, 2009 5:27:55.335 AM', 'Friday, June 24, 2022 9:57:55 PM'] -> [1256102875335, 1656107875000] -> [0xC7, 0xD0, 0x90, 0x75, 0x24, 0x01, 0x00, 0x00, 0xB8, 0xBA, 0xB8, 0x97, 0x81, 0x01, 0x00, 0x00]
 
 [[payloads_payload_representation_on_host_applications]]
 ==== Payload Representation on Host Applications


### PR DESCRIPTION
Fix the following problems:

* The Int8Array example uses the wrong byte for decimal -23.
* The FloatArray and DoubleArray examples have the byte arrays in big endian order instead of little endian order.
* The DateTimeArray example is missing the two most significant bytes for each value.

Fixes #435