### PR TITLE
Fix: Change hasValue to call hasIntValue for uint32 datatypes

### DIFF
--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/common/Utils.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/common/Utils.java
@@ -166,9 +166,9 @@ public class Utils {
 			case Int32:
 			case UInt8:
 			case UInt16:
+			case UInt32:
 				return m.hasIntValue();
 			case Int64:
-			case UInt32:
 			case UInt64:
 			case DateTime:
 				return m.hasLongValue();


### PR DESCRIPTION
Currently, the hasValue function with Utils.java calls hasLongValue when the datatype is 7 (uint32).

This does not align with the Google Protobuf Language Guide which states that uint32 Protobuf values map to an Int type in Java.

https://protobuf.dev/programming-guides/proto3/ (Under 'Scalar Value Types')

This PR fixes this.
