### PR TITLE
Fix data type checks develop

### DIFF
--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/common/Utils.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/common/Utils.java
@@ -152,56 +152,152 @@ public class Utils {
 		return (seq == 255) ? 0 : seq + 1;
 	}
 
+	public static boolean hasValidDatatype(Metric m) {
+        // Checks that the datatype is valid for Metric and that the value case corresponds with the datatype
+        Metric.ValueCase expectedValueCase = Metric.ValueCase.VALUE_NOT_SET;
+
+        if(DataType.forNumber(m.getDatatype()) != null) {
+            switch (DataType.forNumber(m.getDatatype())) {
+                case Int8:
+                case Int16:
+                case Int32:
+                case UInt8:
+                case UInt16:
+                case UInt32:
+                    expectedValueCase = Metric.ValueCase.INT_VALUE;
+                    break;
+                case Int64:
+                case UInt64:
+                case DateTime:
+                    expectedValueCase = Metric.ValueCase.LONG_VALUE;
+                    break;
+                case Float:
+                    expectedValueCase = Metric.ValueCase.FLOAT_VALUE;
+                    break;
+                case Double:
+                    expectedValueCase = Metric.ValueCase.DOUBLE_VALUE;
+                    break;
+                case Boolean:
+                    expectedValueCase = Metric.ValueCase.BOOLEAN_VALUE;
+                    break;
+                case String:
+                case Text:
+                case UUID:
+                    expectedValueCase = Metric.ValueCase.STRING_VALUE;
+                    break;
+                case Bytes:
+                case File:
+                case Int8Array:
+                case Int16Array:
+                case Int32Array:
+                case Int64Array:
+                case UInt8Array:
+                case UInt16Array:
+                case UInt32Array:
+                case UInt64Array:
+                case FloatArray:
+                case DoubleArray:
+                case BooleanArray:
+                case StringArray:
+                case DateTimeArray:
+                    expectedValueCase = Metric.ValueCase.BYTES_VALUE;
+                    break;
+                case DataSet:
+                    expectedValueCase = Metric.ValueCase.DATASET_VALUE;
+                    break;
+                case Template:
+                    expectedValueCase = Metric.ValueCase.TEMPLATE_VALUE;
+                    break;
+                default:
+                    break;
+            }
+        }else {
+            // If Metric does not have datatype, assumed valid
+            return true;
+
+        }
+
+		if(m.getIsNull()){
+			// If Metric is null, Value case will not be set, so just confirms datatype is valid
+			return expectedValueCase != Metric.ValueCase.VALUE_NOT_SET;
+		}
+
+        return DataType.forNumber(m.getDatatype()) != null && expectedValueCase != Metric.ValueCase.VALUE_NOT_SET && m.getValueCase() == expectedValueCase;
+    }
+
+	public static boolean hasValidDatatype(Payload.PropertyValue p) {
+        // Checks that the datatype is valid for Property Values and that the value case corresponds with the datatype
+        Payload.PropertyValue.ValueCase expectedValueCase = Payload.PropertyValue.ValueCase.VALUE_NOT_SET;
+        if (DataType.forNumber(p.getType()) != null) {
+            switch (DataType.forNumber(p.getType())) {
+                case Int8:
+                case Int16:
+                case Int32:
+                case UInt8:
+                case UInt16:
+                case UInt32:
+                    expectedValueCase = Payload.PropertyValue.ValueCase.INT_VALUE;
+                    break;
+                case Int64:
+                case UInt64:
+                    expectedValueCase = Payload.PropertyValue.ValueCase.LONG_VALUE;
+                    break;
+                case Float:
+                    expectedValueCase = Payload.PropertyValue.ValueCase.FLOAT_VALUE;
+                    break;
+                case Double:
+                    expectedValueCase = Payload.PropertyValue.ValueCase.DOUBLE_VALUE;
+                    break;
+                case Boolean:
+                    expectedValueCase = Payload.PropertyValue.ValueCase.BOOLEAN_VALUE;
+                    break;
+                case String:
+                case Text:
+                case UUID:
+                    expectedValueCase = Payload.PropertyValue.ValueCase.STRING_VALUE;
+                    break;
+                default:
+                    break;
+            }
+        } else {
+            // If Property Value does not have type, assumed valid
+            return true;
+
+        }
+		if(p.getIsNull()){
+			// If Property Value is null, Value case will not be set, so just confirms datatype is valid
+			return expectedValueCase != Payload.PropertyValue.ValueCase.VALUE_NOT_SET;
+		}
+        return DataType.forNumber(p.getType()) != null && expectedValueCase != Payload.PropertyValue.ValueCase.VALUE_NOT_SET && p.getValueCase() == expectedValueCase;
+    }
+
 	public static boolean hasValue(Metric m) {
 		if (m.hasIsNull() && m.getIsNull()) {
 			// A null value is valid
 			return true;
 		}
 
-		switch (DataType.forNumber(m.getDatatype())) {
-			case Unknown:
-				return false;
-			case Int8:
-			case Int16:
-			case Int32:
-			case UInt8:
-			case UInt16:
+		switch(m.getValueCase()){
+			case INT_VALUE:
 				return m.hasIntValue();
-			case Int64:
-			case UInt32:
-			case UInt64:
-			case DateTime:
+			case LONG_VALUE:
 				return m.hasLongValue();
-			case Float:
+			case FLOAT_VALUE:
 				return m.hasFloatValue();
-			case Double:
+			case DOUBLE_VALUE:
 				return m.hasDoubleValue();
-			case Boolean:
+			case BOOLEAN_VALUE:
 				return m.hasBooleanValue();
-			case String:
-			case Text:
-			case UUID:
+			case STRING_VALUE:
 				return m.hasStringValue();
-			case Bytes:
-			case File:
-			case Int8Array:
-			case Int16Array:
-			case Int32Array:
-			case Int64Array:
-			case UInt8Array:
-			case UInt16Array:
-			case UInt32Array:
-			case UInt64Array:
-			case FloatArray:
-			case DoubleArray:
-			case BooleanArray:
-			case StringArray:
-			case DateTimeArray:
+			case BYTES_VALUE:
 				return m.hasBytesValue();
-			case DataSet:
+			case DATASET_VALUE:
 				return m.hasDatasetValue();
-			case Template:
+			case TEMPLATE_VALUE:
 				return m.hasTemplateValue();
+			case EXTENSION_VALUE:
+				return m.hasExtensionValue();
 			default:
 				return false;
 		}
@@ -211,22 +307,26 @@ public class Utils {
 		if (!p.hasType()) {
 			return false;
 		}
-		switch (p.getType()) {
-			case Parameter.INT_VALUE_FIELD_NUMBER:
+
+		switch (p.getValueCase()){
+			case INT_VALUE:
 				return p.hasIntValue();
-			case Parameter.LONG_VALUE_FIELD_NUMBER:
+			case LONG_VALUE:
 				return p.hasLongValue();
-			case Parameter.FLOAT_VALUE_FIELD_NUMBER:
+			case FLOAT_VALUE:
 				return p.hasFloatValue();
-			case Parameter.DOUBLE_VALUE_FIELD_NUMBER:
+			case DOUBLE_VALUE:
 				return p.hasDoubleValue();
-			case Parameter.BOOLEAN_VALUE_FIELD_NUMBER:
+			case BOOLEAN_VALUE:
 				return p.hasBooleanValue();
-			case Parameter.STRING_VALUE_FIELD_NUMBER:
+			case STRING_VALUE:
 				return p.hasStringValue();
+			case EXTENSION_VALUE:
+				return p.hasExtensionValue();
 			default:
 				return false;
 		}
+
 	}
 
 	public static String getRetained(String topic) {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendComplexDataTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendComplexDataTest.java
@@ -98,6 +98,7 @@ import static org.eclipse.sparkplug.tck.test.common.Requirements.PAYLOADS_TEMPLA
 import static org.eclipse.sparkplug.tck.test.common.Requirements.PAYLOADS_TEMPLATE_REF_INSTANCE;
 import static org.eclipse.sparkplug.tck.test.common.Requirements.PAYLOADS_TEMPLATE_VERSION;
 import static org.eclipse.sparkplug.tck.test.common.Utils.setResult;
+import static org.eclipse.sparkplug.tck.test.common.Utils.setResultIfNotFail;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -370,23 +371,22 @@ public class SendComplexDataTest extends TCKTest {
 			isValid_DataTypeValue = false;
 			logger.error("Check req set for : {}", ID_PAYLOADS_METRIC_DATATYPE_VALUE_TYPE);
 		}
-		testResults.put(ID_PAYLOADS_METRIC_DATATYPE_VALUE_TYPE,
-				setResult(isValid_DataType, PAYLOADS_METRIC_DATATYPE_VALUE_TYPE));
 
 		logger.debug(
 				"Check Req: The datatype MUST be one of the enumerated values as shown in the valid Sparkplug Data Types.");
 		if (result != null) {
 			for (Metric m : result.getMetricsList()) {
-				if (DataType.forNumber(m.getDatatype()) == null
-						|| DataType.Unknown == DataType.forNumber(m.getDatatype())) {
+				if(!Utils.hasValidDatatype(m)){
+					isValid_DataType = false;
 					isValid_DataTypeValue = false;
 					break;
 				}
 			}
 		}
 
-		testResults.put(ID_PAYLOADS_METRIC_DATATYPE_VALUE,
-				setResult(isValid_DataTypeValue, PAYLOADS_METRIC_DATATYPE_VALUE));
+		setResultIfNotFail(testResults,isValid_DataType,ID_PAYLOADS_METRIC_DATATYPE_VALUE_TYPE,PAYLOADS_METRIC_DATATYPE_VALUE_TYPE);
+
+		setResultIfNotFail(testResults,isValid_DataTypeValue,ID_PAYLOADS_METRIC_DATATYPE_VALUE,PAYLOADS_METRIC_DATATYPE_VALUE);
 	}
 
 	@SpecAssertion(
@@ -454,8 +454,7 @@ public class SendComplexDataTest extends TCKTest {
 
 				for (int i = 0; i < m.getProperties().getValuesCount(); i++) {
 					final Payload.PropertyValue propertyValue = m.getProperties().getValues(i);
-					if (propertyValue.getValueCase() == null
-							|| Payload.PropertyValue.ValueCase.VALUE_NOT_SET == propertyValue.getValueCase()) {
+					if(!Utils.hasValidDatatype(propertyValue)){
 						isValid_PropertyValueType = false;
 						isValid_PropertyValueTypeValue = false;
 					}
@@ -479,12 +478,9 @@ public class SendComplexDataTest extends TCKTest {
 		testResults.put(ID_PAYLOADS_PROPERTYSET_VALUES_ARRAY_SIZE,
 				setResult(isValid_KeyArraySize, PAYLOADS_PROPERTYSET_VALUES_ARRAY_SIZE));
 
-		testResults.put(ID_PAYLOADS_METRIC_PROPERTYVALUE_TYPE_TYPE,
-				setResult(isValid_PropertyValueType, PAYLOADS_METRIC_PROPERTYVALUE_TYPE_TYPE));
-		testResults.put(ID_PAYLOADS_METRIC_PROPERTYVALUE_TYPE_VALUE,
-				setResult(isValid_PropertyValueTypeValue, PAYLOADS_METRIC_PROPERTYVALUE_TYPE_VALUE));
-		testResults.put(ID_PAYLOADS_METRIC_PROPERTYVALUE_TYPE_REQ,
-				setResult(isValid_PropertyValueTypeReq, PAYLOADS_METRIC_PROPERTYVALUE_TYPE_REQ));
+		setResultIfNotFail(testResults,isValid_PropertyValueType,ID_PAYLOADS_METRIC_PROPERTYVALUE_TYPE_TYPE,PAYLOADS_METRIC_PROPERTYVALUE_TYPE_TYPE);
+		setResultIfNotFail(testResults,isValid_PropertyValueTypeValue,ID_PAYLOADS_METRIC_PROPERTYVALUE_TYPE_VALUE,PAYLOADS_METRIC_PROPERTYVALUE_TYPE_VALUE);
+		setResultIfNotFail(testResults,isValid_PropertyValueTypeReq,ID_PAYLOADS_METRIC_PROPERTYVALUE_TYPE_REQ,PAYLOADS_METRIC_PROPERTYVALUE_TYPE_REQ);
 
 	}
 


### PR DESCRIPTION
This PR forward ports fixes made to the 3.x branch to the develop branch

PR on the 3.x: https://github.com/eclipse-sparkplug/sparkplug/pull/469

This PR fixes three bugs and makes some improvement:
Bugs

   - If PAYLOADS_METRIC_PROPERTYVALUE_TYPE_VALUE is found to be invalid for one payload however valid for a subsequent payload, the test is passed. If this test fails once, it should be recorded as a fail.
   - PAYLOADS_METRIC_PROPERTYVALUE_TYPE_VALUE Checks PropertyValue.Type against the wire values:
    int_value = 3;
    uint64 long_value = 4;
    float float_value = 5;
    It should be checked against the enum 'DataType'
   - Metric.hasValue checks for an uint64 when datatype 7 (uint32) is passed in. This should check for a uint32 value

Other changes

  -  Switch hasValue functions to use ValueCase and shift datatype validation into separate functions

Please comment any questions regarding this PR


