### PR TITLE
Handle HiveMQ broker disconnection in the web console

### DIFF
--- a/tck/webconsole/components/MqttConnect.vue
+++ b/tck/webconsole/components/MqttConnect.vue
@@ -1,5 +1,5 @@
 <!--****************************************************************************
- * Copyright (c) 2021, 2022 Lukas Brand, Ian Craggs
+ * Copyright (c) 2021, 2023 Lukas Brand, Ian Craggs
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -251,6 +251,9 @@ export default {
         this.mqttClient.on("connect", () => {
             this.successCountDown = 5;
             console.log("Connection succeeded!");
+        });
+        this.mqttClient.on("offline", () => {
+            console.log("Connection broken!");
         });
         this.mqttClient.on("error", (error) => {
             this.failureCountDown = 5;

--- a/tck/webconsole/components/Tck/Test.vue
+++ b/tck/webconsole/components/Tck/Test.vue
@@ -398,14 +398,24 @@ export default {
     computed: {
         loggingSplitInLines: function () {
             let logLines = [];
+            let index = 0;
             for (const logMessage of this.test.logging) {
                 const lines = logMessage.logValue.trim().split(/\r\n|\n\r|\n|\r/);
                 console.log(lines);
                 logLines = logLines.concat(lines);
 
-                if (lines[0].includes("Test started successfully:")) {
-                    this.testState(this.test);
+                if (index == this.test.logging.length -1) {
+                    if (lines[0].includes("Test started successfully:")) {
+                        this.testState(this.test);
+                    }
+
+                    if (lines[0].includes("Test aborted")) {
+                        console.log("resetting test");
+                        this.resetState(this.test);
+                        alert("Test aborted - lost connection to HiveMQ broker.");
+                    }
                 }
+                index++;
             }
             logLines = logLines.filter((line) => line.trim().length != 0);
             return logLines;
@@ -445,7 +455,6 @@ export default {
         },
 
         testState(test) {
-
             if (test.testType === "HOSTAPPLICATION") {
                 this.startH = !this.startH;
                 this.stopH = !this.stopH;

--- a/tck/webconsole/components/Tck/Tests.vue
+++ b/tck/webconsole/components/Tck/Tests.vue
@@ -1,5 +1,5 @@
 <!--****************************************************************************
- * Copyright (c) 2021, 2022 Lukas Brand, Ian Craggs
+ * Copyright (c) 2021, 2023 Lukas Brand, Ian Craggs
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -74,6 +74,7 @@ export default {
 
         currentTestLogging: null,
         currentTest: null,
+        connected: null,
     },
 
     computed: {
@@ -129,6 +130,56 @@ export default {
     },
 
     watch: {
+        /*
+         * Reset the current test if we lose the MQTT connection
+         */
+        connected: function (newValue, oldValue) {
+            console.log("newvalue", newValue, this.testType, this.currentTest);
+            if (newValue != false) return;
+            if (this.testType == null || this.currentTest == null) return;
+
+            if (this.testType === "HOSTAPPLICATION") {
+                for (const [_, testValue] of Object.entries(this.hostTests)) {
+                    if (testValue.testValues.name === this.currentTest) {
+                        console.log("Test aborted - MQTT connection broken");
+
+                        const logMessage = {
+                            logLevel: "INFO",
+                            logValue: "Test aborted - MQTT connection broken",
+                            id: 10,
+                        };
+                        testValue.testValues.logging.push(logMessage);
+                    }
+                }
+            } else if (this.testType === "EONNODE") {
+                for (const [_, testValue] of Object.entries(this.eonTests)) {
+                    if (testValue.testValues.name === this.currentTest) {
+                        console.log("Test aborted - MQTT connection broken");
+
+                        const logMessage = {
+                            logLevel: "INFO",
+                            logValue: "Test aborted - MQTT connection broken",
+                            id: 10,
+                        };
+                        testValue.testValues.logging.push(logMessage);
+                    }
+                }
+            } else if (this.testType === "BROKER") {
+                for (const [_, testValue] of Object.entries(this.brokerTests)) {
+                    if (testValue.testValues.name === this.currentTest) {
+                        console.log("Test aborted - MQTT connection broken");
+
+                        const logMessage = {
+                            logLevel: "INFO",
+                            logValue: "Test aborted - MQTT connection broken",
+                            id: 10,
+                        };
+                        testValue.testValues.logging.push(logMessage);
+                    }
+                }
+            }
+            this.$emit("reset-current-test");
+        },
         /**
          * Updates test with logging.
          * @param {String} newValue - New current tests logging

--- a/tck/webconsole/pages/index.vue
+++ b/tck/webconsole/pages/index.vue
@@ -77,6 +77,7 @@
                 <TckTests
                     :currentTest="this.currentTest"
                     :currentTestLogging="this.currentTestLogging"
+                    :connected="this.mqttClient.connected"
                     :testType="this.sparkplugClient.testType"
                     class="mt-3"
                     @start-all-tests="(hostTests, eonTests, brokerTests) => startAllTestsFun(hostTests, eonTests, brokerTests)"
@@ -104,7 +105,6 @@
         </b-button>
     </div>
 </template>
-
 
 <script>
 


### PR DESCRIPTION
If the MQTT connection to the controlling HiveMQ broker is broken when a test is running, abort that test.