### PR TITLE
Update 3.x tck branch version to 3.0.1-SNAPSHOT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ spec:
           [$class: 'StringBinding', credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE']
         ]) {
           sh '''
-            curl -o tck/build/hivemq-extension/sparkplug-tck-3.0.0-signed.jar -F file=@tck/build/hivemq-extension/sparkplug-tck-3.0.0.jar https://cbi.eclipse.org/jarsigner/sign
+            curl -o tck/build/hivemq-extension/sparkplug-tck-3.0.1-SNAPSHOT-signed.jar -F file=@tck/build/hivemq-extension/sparkplug-tck-3.0.1-SNAPSHOT.jar https://cbi.eclipse.org/jarsigner/sign
             export GPG_TTY=/dev/console
 
             gpg --batch --import "${KEYRING}"
@@ -57,18 +57,18 @@ spec:
 
             mkdir tck/build/hivemq-extension/working_tmp
             cd tck/build/hivemq-extension/working_tmp
-            unzip ../sparkplug-tck-3.0.0.zip
-            mv ../sparkplug-tck-3.0.0-signed.jar sparkplug-tck/sparkplug-tck-3.0.0.jar
-            zip -r ../sparkplug-tck-3.0.0.zip sparkplug-tck
+            unzip ../sparkplug-tck-3.0.1-SNAPSHOT.zip
+            mv ../sparkplug-tck-3.0.1-SNAPSHOT-signed.jar sparkplug-tck/sparkplug-tck-3.0.1-SNAPSHOT.jar
+            zip -r ../sparkplug-tck-3.0.1-SNAPSHOT.zip sparkplug-tck
             cd ..
-            gpg -v --no-tty --passphrase "${KEYRING_PASSPHRASE}" -c --batch sparkplug-tck-3.0.0.zip
+            gpg -v --no-tty --passphrase "${KEYRING_PASSPHRASE}" -c --batch sparkplug-tck-3.0.1-SNAPSHOT.zip
 
             echo "no-tty" >> ~/.gnupg/gpg.conf
-            gpg -vvv --no-permission-warning --output "sparkplug-tck-3.0.0.zip.sig" --batch --yes --pinentry-mode=loopback --passphrase="${KEYRING_PASSPHRASE}" --no-tty --detach-sig sparkplug-tck-3.0.0.zip
+            gpg -vvv --no-permission-warning --output "sparkplug-tck-3.0.1-SNAPSHOT.zip.sig" --batch --yes --pinentry-mode=loopback --passphrase="${KEYRING_PASSPHRASE}" --no-tty --detach-sig sparkplug-tck-3.0.1-SNAPSHOT.zip
             cd ../../
             ./package.sh
-            gpg -vvv --no-permission-warning --output "Eclipse-Sparkplug-TCK-3.0.0.zip.sig" --batch --yes --pinentry-mode=loopback --passphrase="${KEYRING_PASSPHRASE}" --no-tty --detach-sig Eclipse-Sparkplug-TCK-3.0.0.zip
-            gpg -vvv --verify Eclipse-Sparkplug-TCK-3.0.0.zip.sig
+            gpg -vvv --no-permission-warning --output "Eclipse-Sparkplug-TCK-3.0.1-SNAPSHOT.zip.sig" --batch --yes --pinentry-mode=loopback --passphrase="${KEYRING_PASSPHRASE}" --no-tty --detach-sig Eclipse-Sparkplug-TCK-3.0.1-SNAPSHOT.zip
+            gpg -vvv --verify Eclipse-Sparkplug-TCK-3.0.1-SNAPSHOT.zip.sig
           '''
         }
       }
@@ -78,10 +78,10 @@ spec:
       steps {
         sshagent(credentials: ['projects-storage.eclipse.org-bot-ssh']) {
           sh '''
-            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes genie.sparkplug@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/sparkplug/*
-            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes genie.sparkplug@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/sparkplug/3.0.0
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes tck/Eclipse-Sparkplug-TCK-3.0.0.zip genie.sparkplug@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/sparkplug/3.0.0/
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes tck/Eclipse-Sparkplug-TCK-3.0.0.zip.sig genie.sparkplug@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/sparkplug/3.0.0/
+            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes genie.sparkplug@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/sparkplug/snapshot/*
+            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes genie.sparkplug@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/sparkplug/snapshot
+            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes tck/Eclipse-Sparkplug-TCK-3.0.1-SNAPSHOT.zip genie.sparkplug@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/sparkplug/snapshot
+            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes tck/Eclipse-Sparkplug-TCK-3.0.1-SNAPSHOT.zip.sig genie.sparkplug@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/sparkplug/snapshot/
           '''
         }
       }

--- a/specification/gradle.properties
+++ b/specification/gradle.properties
@@ -1,4 +1,4 @@
-version=3.0.0
+version=3.0.1-SNAPSHOT
 #
 # main props
 #

--- a/specification/src/main/asciidoc/sparkplug_spec.adoc
+++ b/specification/src/main/asciidoc/sparkplug_spec.adoc
@@ -8,9 +8,9 @@ https://www.eclipse.org/legal/epl-2.0.
 SPDX-License-Identifier: EPL-2.0
 ////
 
-= Sparkplug 3.0.0: Sparkplug Specification
+= Sparkplug 3.0.1-SNAPSHOT: Sparkplug Specification
 Eclipse Sparkplug Contributors
-Version 3.0.0 Release, {docdate}
+Version 3.0.1-SNAPSHOT, {docdate}
 // Settings:
 //:experimental:
 :reproducible:

--- a/specification/src/main/xsl/tck-audit.xsl
+++ b/specification/src/main/xsl/tck-audit.xsl
@@ -186,8 +186,8 @@
 
         <specification xmlns="http://jboss.com/products/weld/tck/audit"
                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xsi:schemaLocation="http://jboss.com/products/weld/tck/audit" name="Sparkplug 3.0.0"
-                       version="3.0.0" id="sparkplug" generateSectionIds="true">
+                       xsi:schemaLocation="http://jboss.com/products/weld/tck/audit" name="Sparkplug 3.0.1-SNAPSHOT"
+                       version="3.0.1-SNAPSHOT" id="sparkplug" generateSectionIds="true">
 
             <xsl:apply-templates mode="createAuditFile"/>
 

--- a/tck/UserGuide.adoc
+++ b/tck/UserGuide.adoc
@@ -28,7 +28,7 @@ which controls the running of the tests.
 
 Install the HiveMQ broker following the instructions provided with it.
 
-Copy the extension distribution file (tck/build/hivemq-extension/sparkplug-tck-3.0.0.zip)
+Copy the extension distribution file (tck/build/hivemq-extension/sparkplug-tck-3.0.1-SNAPSHOT.zip)
 to the HiveMQ extension folder (extensions), and unzip the file there. 
 The target folder should now have the following content.
 
@@ -36,13 +36,13 @@ The target folder should now have the following content.
 |-| extensions/
   |-| sparkplug-tck/
     |--  hivemq-extension.xml
-    |--  sparkplug-tck-3.0.0.jar
+    |--  sparkplug-tck-3.0.1-SNAPSHOT.jar
 ----
 
 Now, on starting the HiveMQ broker, this message should be seen:
 
 ----
-Extension "Eclipse™ Sparkplug™ TCK" version 3.0.0 started successfully.
+Extension "Eclipse™ Sparkplug™ TCK" version 3.0.1-SNAPSHOT started successfully.
 ----
 
 Add a websocket listener to the HiveMQ broker by updating the config.xml file.

--- a/tck/gradle.properties
+++ b/tck/gradle.properties
@@ -1,4 +1,4 @@
-version=3.0.0
+version=3.0.1-SNAPSHOT
 #
 # main props
 #

--- a/tck/package.py
+++ b/tck/package.py
@@ -64,7 +64,7 @@ except:
     pass
 
 # generate signature for HiveMQ extension file - this needs to be run with the correct gpg identity
-os.system("gpg --batch --yes --detach-sign build/hivemq-extension/sparkplug-tck-3.0.0.zip")
+os.system("gpg --batch --yes --detach-sign build/hivemq-extension/sparkplug-tck-3.0.1-SNAPSHOT.zip")
 
 # Update the UserGuide.html doc
 os.system("asciidoc UserGuide.adoc")

--- a/tck/package.py
+++ b/tck/package.py
@@ -17,8 +17,8 @@ import zipfile, glob, os, sys
 files = \
 ["build/coverage-report/",
 "eftckl-v10",
-"build/hivemq-extension/sparkplug-tck-3.0.0.zip",
-"build/hivemq-extension/sparkplug-tck-3.0.0.zip.sig",
+"build/hivemq-extension/sparkplug-tck-3.0.1-SNAPSHOT.zip",
+"build/hivemq-extension/sparkplug-tck-3.0.1-SNAPSHOT.zip.sig",
 "hivemq-configuration/",
 "report.py",
 "UserGuide.html",
@@ -55,7 +55,7 @@ files = \
 "src//main/java/org/eclipse/sparkplug/tck/test/Monitor.java"
 ]
 
-zipfilename = "Eclipse-Sparkplug-TCK-3.0.0.zip"
+zipfilename = "Eclipse-Sparkplug-TCK-3.0.1-SNAPSHOT.zip"
 prefix = "SparkplugTCK/"
 
 try:
@@ -70,7 +70,7 @@ os.system("gpg --batch --yes --detach-sign build/hivemq-extension/sparkplug-tck-
 os.system("asciidoc UserGuide.adoc")
 
 # update the tck jar notices directory
-jarfilename = "build/hivemq-extension/sparkplug-tck-3.0.0.jar"
+jarfilename = "build/hivemq-extension/sparkplug-tck-3.0.1-SNAPSHOT.jar"
 
 # get the webconsole directory except the node_modules subdir
 webconsole_files = glob.glob("webconsole/*")

--- a/tck/package.sh
+++ b/tck/package.sh
@@ -17,8 +17,8 @@ FILES="build/coverage-report/coverage-sparkplug.html
 build/coverage-report/images/stickynote.png
 build/coverage-report/images/blank.png
 eftckl-v10
-build/hivemq-extension/sparkplug-tck-3.0.0.zip
-build/hivemq-extension/sparkplug-tck-3.0.0.zip.sig
+build/hivemq-extension/sparkplug-tck-3.0.1-SNAPSHOT.zip
+build/hivemq-extension/sparkplug-tck-3.0.1-SNAPSHOT.zip.sig
 hivemq-configuration/logback.xml
 hivemq-configuration/config.xml
 report.py
@@ -26,7 +26,7 @@ UserGuide.html
 README.md
 README.html"
 
-ZIP_FILE_NAME=Eclipse-Sparkplug-TCK-3.0.0.zip
+ZIP_FILE_NAME=Eclipse-Sparkplug-TCK-3.0.1-SNAPSHOT.zip
 PREFIX=build/SparkplugTCK/
 
 # Delete the old version

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/Monitor.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/Monitor.java
@@ -162,7 +162,7 @@ import com.hivemq.extension.sdk.api.packets.subscribe.SubscribePacket;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class Monitor extends TCKTest implements ClientLifecycleEventListener {
 
 	private static Logger logger = LoggerFactory.getLogger("Sparkplug");

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/Results.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/Results.java
@@ -46,7 +46,7 @@ import com.hivemq.extension.sdk.api.services.admin.LifecycleStage;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class Results implements MqttCallbackExtended {
 	private static final Logger logger = LoggerFactory.getLogger("Sparkplug");
 	protected static final String SPARKPLUG_TCKRESULTS_LOG = "SparkplugTCKresults.log";

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/AwareBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/AwareBrokerTest.java
@@ -70,7 +70,7 @@ import com.hivemq.extension.sdk.api.services.Services;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class AwareBrokerTest extends TCKTest {
 	private static final Logger logger = LoggerFactory.getLogger("Sparkplug");
 	private final @NotNull List<String> testIds = List.of(ID_CONFORMANCE_MQTT_AWARE_BASIC,

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/CompliantBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/CompliantBrokerTest.java
@@ -61,7 +61,7 @@ import com.hivemq.extension.sdk.api.services.Services;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class CompliantBrokerTest extends TCKTest {
 	private static final Logger logger = LoggerFactory.getLogger("Sparkplug");
 	private static final int TIME_OUT = 60;

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/MultipleBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/MultipleBrokerTest.java
@@ -74,7 +74,7 @@ import com.hivemq.extension.sdk.api.services.Services;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class MultipleBrokerTest extends TCKTest {
 	private static final Logger logger = LoggerFactory.getLogger("Sparkplug");
 	private final @NotNull Map<String, String> testResults = new HashMap<>();

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/PrimaryHostTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/PrimaryHostTest.java
@@ -78,7 +78,7 @@ import com.hivemq.extension.sdk.api.services.Services;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class PrimaryHostTest extends TCKTest {
 
 	private static final @NotNull Logger logger = LoggerFactory.getLogger("Sparkplug");

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/ReceiveCommandTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/ReceiveCommandTest.java
@@ -92,7 +92,7 @@ import com.hivemq.extension.sdk.api.services.session.ClientService;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class ReceiveCommandTest extends TCKTest {
 
 	private static final String BD_SEQ = "bdSeq";

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendComplexDataTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendComplexDataTest.java
@@ -136,7 +136,7 @@ import com.hivemq.extension.sdk.api.packets.subscribe.SubscribePacket;
  */
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class SendComplexDataTest extends TCKTest {
 
 	private static final @NotNull Logger logger = LoggerFactory.getLogger("Sparkplug");

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendDataTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendDataTest.java
@@ -130,7 +130,7 @@ import com.hivemq.extension.sdk.api.packets.subscribe.SubscribePacket;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class SendDataTest extends TCKTest {
 
 	private static Logger logger = LoggerFactory.getLogger("Sparkplug");

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SessionEstablishmentTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SessionEstablishmentTest.java
@@ -76,7 +76,7 @@ import com.hivemq.extension.sdk.api.services.publish.PublishService;
  */
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class SessionEstablishmentTest extends TCKTest {
 	private static final @NotNull Logger logger = LoggerFactory.getLogger("Sparkplug");
 

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SessionTerminationTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SessionTerminationTest.java
@@ -87,7 +87,7 @@ import com.hivemq.extension.sdk.api.packets.subscribe.SubscribePacket;
  */
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class SessionTerminationTest extends TCKTest {
 	private static final @NotNull Logger logger = LoggerFactory.getLogger("Sparkplug");
 

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/EdgeSessionTerminationTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/EdgeSessionTerminationTest.java
@@ -75,7 +75,7 @@ import com.hivemq.extension.sdk.api.services.publish.PublishService;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class EdgeSessionTerminationTest extends TCKTest {
 
 	private static Logger logger = LoggerFactory.getLogger("Sparkplug");

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MessageOrderingTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MessageOrderingTest.java
@@ -80,7 +80,7 @@ import com.hivemq.extension.sdk.api.services.publish.PublishService;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class MessageOrderingTest extends TCKTest {
 	private static final Logger logger = LoggerFactory.getLogger("Sparkplug");
 	private final @NotNull Map<String, String> testResults = new HashMap<>();

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MultipleBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MultipleBrokerTest.java
@@ -69,7 +69,7 @@ import com.hivemq.extension.sdk.api.services.session.ClientService;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class MultipleBrokerTest extends TCKTest {
 
 	private static final Logger logger = LoggerFactory.getLogger("Sparkplug");

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SendCommandTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SendCommandTest.java
@@ -135,7 +135,7 @@ import com.hivemq.extension.sdk.api.services.publish.PublishService;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class SendCommandTest extends TCKTest {
 
 	private static final String NODE_CONTROL_REBIRTH = "Node Control/Rebirth";

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionEstablishmentTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionEstablishmentTest.java
@@ -155,7 +155,7 @@ import com.hivemq.extension.sdk.api.services.publish.PublishService;
  */
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class SessionEstablishmentTest extends TCKTest {
 	private static final @NotNull Logger logger = LoggerFactory.getLogger("Sparkplug");
 

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionTerminationTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/SessionTerminationTest.java
@@ -76,7 +76,7 @@ import com.hivemq.extension.sdk.api.packets.subscribe.SubscribePacket;
  */
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class SessionTerminationTest extends TCKTest {
 	private static final Logger logger = LoggerFactory.getLogger("Sparkplug");
 

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/utility/EdgeNode.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/utility/EdgeNode.java
@@ -76,7 +76,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class EdgeNode {
 
 	private static final Logger logger = LoggerFactory.getLogger("Sparkplug");

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/utility/HostApplication.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/utility/HostApplication.java
@@ -42,7 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpecVersion(
 		spec = "sparkplug",
-		version = "3.0.0")
+		version = "3.0.1-SNAPSHOT")
 public class HostApplication {
 
 	private static Logger logger = LoggerFactory.getLogger("Sparkplug");


### PR DESCRIPTION
I think this is not what we want yet - the specification version numbers should remain at 3.0.0 while the TCK goes to 3.0.1-SNAPSHOT. I took the commit directly from the develop branch which is why they've all been changed. I'll add another commit to fix this if you agree this is what we want @wes-johnson 