### PR TITLE
Fix test naming inconsistencies (develop)

### DIFF
--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/AwareBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/AwareBrokerTest.java
@@ -130,7 +130,7 @@ public class AwareBrokerTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Broker Sparkplug Aware";
+		return "Broker SparkplugAware";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/CompliantBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/broker/CompliantBrokerTest.java
@@ -141,7 +141,7 @@ public class CompliantBrokerTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Broker Sparkplug Compliant";
+		return "Broker SparkplugCompliant";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/MultipleBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/MultipleBrokerTest.java
@@ -274,7 +274,7 @@ public class MultipleBrokerTest extends TCKTest {
 
 	@Override
 	public String getName() {
-		return "Edge Multiple Broker";
+		return "Edge MultipleBroker";
 	}
 
 	@Override

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/PrimaryHostTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/PrimaryHostTest.java
@@ -323,7 +323,7 @@ public class PrimaryHostTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Edge Primary Host";
+		return "Edge PrimaryHost";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendComplexDataTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendComplexDataTest.java
@@ -219,7 +219,7 @@ public class SendComplexDataTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Edge Send Complex Data";
+		return "Edge SendComplexData";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/EdgeSessionTerminationTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/EdgeSessionTerminationTest.java
@@ -155,7 +155,7 @@ public class EdgeSessionTerminationTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Sparkplug Host Edge Node Session Termination Test";
+		return "Host EdgeNodeSessionTermination";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/EdgeSessionTerminationTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/EdgeSessionTerminationTest.java
@@ -155,7 +155,7 @@ public class EdgeSessionTerminationTest extends TCKTest {
 	}
 
 	public String getName() {
-		return "Host EdgeNodeSessionTermination";
+		return "Host EdgeSessionTermination";
 	}
 
 	public String[] getTestIds() {

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MessageOrderingTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MessageOrderingTest.java
@@ -165,7 +165,7 @@ public class MessageOrderingTest extends TCKTest {
 
 	@Override
 	public String getName() {
-		return "Host Message Ordering";
+		return "Host MessageOrdering";
 	}
 
 	@Override

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MultipleBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/host/MultipleBrokerTest.java
@@ -196,7 +196,7 @@ public class MultipleBrokerTest extends TCKTest {
 
 	@Override
 	public String getName() {
-		return "Host Multiple Broker";
+		return "Host MultipleBroker";
 	}
 
 	@Override


### PR DESCRIPTION
Currently the getName function for different tests returns the name of the test with inconsistencies in the formatting. 
This PR adopts a consistent style across test names.