### PR TITLE
Allow nodes without a separate device #517

### DIFF
--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/MultipleBrokerTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/MultipleBrokerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Ian Craggs
+ * Copyright (c) 2021, 2024 Ian Craggs
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -84,11 +84,11 @@ public class MultipleBrokerTest extends TCKTest {
 					ID_OPERATIONAL_BEHAVIOR_PRIMARY_APPLICATION_STATE_WITH_MULTIPLE_SERVERS_WALK,
 					ID_OPERATIONAL_BEHAVIOR_EDGE_NODE_BIRTH_SEQUENCE_WAIT);
 
-	private @NotNull String deviceId;
-	private @NotNull String groupId;
-	private @NotNull String edgeNodeId;
-	private @NotNull String hostApplicationId;
-	private @NotNull String brokerURL;
+	private @NotNull String deviceId = null;
+	private @NotNull String groupId = null;
+	private @NotNull String edgeNodeId = null;
+	private @NotNull String hostApplicationId = null;
+	private @NotNull String brokerURL = null;
 
 	private HostApplication broker2 = new HostApplication("tcp://localhost:1884");
 
@@ -111,16 +111,20 @@ public class MultipleBrokerTest extends TCKTest {
 		// a portion of the bdSeq numbers
 		utilities.getMonitor().setIgnoreBdSeqNumCheck(true);
 
-		if (parms.length < 5) {
+		if (parms.length < 4) {
 			log("Not enough parameters: " + Arrays.toString(parms));
-			log("Parameters to edge multiple broker test must be: hostApplicationId, groupId edgeNodeId deviceId brokerURL");
+			log("Parameters to edge multiple broker test must be: hostApplicationId, groupId edgeNodeId {deviceId} brokerURL");
 			throw new IllegalArgumentException();
 		}
 		hostApplicationId = parms[0];
 		groupId = parms[1];
 		edgeNodeId = parms[2];
-		deviceId = parms[3];
-		brokerURL = parms[4];
+		if (parms.length == 4) {
+			brokerURL = parms[3];
+		} else {
+			deviceId = parms[3];
+			brokerURL = parms[4];
+		}
 		logger.info("Parameters are HostApplicationId: {}, GroupId: {}, EdgeNodeId: {}, DeviceId: {} BrokerURL: {}",
 				hostApplicationId, groupId, edgeNodeId, deviceId, brokerURL);
 
@@ -358,9 +362,30 @@ public class MultipleBrokerTest extends TCKTest {
 				Utils.setResultIfNotFail(testResults, true, ID_OPERATIONAL_BEHAVIOR_EDGE_NODE_BIRTH_SEQUENCE_WAIT,
 						OPERATIONAL_BEHAVIOR_EDGE_NODE_BIRTH_SEQUENCE_WAIT);
 
+				if (deviceId == null) {
+					// we've received NBIRTH, and not expecting DBIRTH, so set the second host online
+					executorService.schedule(new Runnable() {
+						@Override
+						public void run() {
+							setHost2Online();
+						}
+					}, 1, TimeUnit.SECONDS);
+				}
+
 			} else if (state == TestStatus.EXPECT_DEATHS_AND_BIRTHS && births_on == 1) {
 				Utils.setResultIfNotFail(testResults, true, ID_OPERATIONAL_BEHAVIOR_EDGE_NODE_BIRTH_SEQUENCE_WAIT,
 						OPERATIONAL_BEHAVIOR_EDGE_NODE_BIRTH_SEQUENCE_WAIT);
+
+				if (deviceId == null) { // there's not going to be a DBIRTH
+					// the edge node has reconnected to server 1 so that's the end of the test
+					state = TestStatus.ENDING;
+					executorService.schedule(new Runnable() {
+						@Override
+						public void run() {
+							theTCK.endTest();
+						}
+					}, 1, TimeUnit.SECONDS);
+				}
 
 			} else {
 				// any other state is wrong
@@ -373,7 +398,7 @@ public class MultipleBrokerTest extends TCKTest {
 				Utils.setResult(testResults, false, ID_OPERATIONAL_BEHAVIOR_EDGE_NODE_BIRTH_SEQUENCE_WAIT,
 						OPERATIONAL_BEHAVIOR_EDGE_NODE_BIRTH_SEQUENCE_WAIT);
 			}
-		} else if (topic.equals(Constants.TOPIC_ROOT_SP_BV_1_0 + "/" + groupId + "/" + Constants.TOPIC_PATH_DBIRTH + "/"
+		} else if (deviceId != null && topic.equals(Constants.TOPIC_ROOT_SP_BV_1_0 + "/" + groupId + "/" + Constants.TOPIC_PATH_DBIRTH + "/"
 				+ edgeNodeId + "/" + deviceId)) {
 			// found the device DBIRTH
 			dbirthReceived = true;
@@ -428,7 +453,7 @@ public class MultipleBrokerTest extends TCKTest {
 						ID_OPERATIONAL_BEHAVIOR_PRIMARY_APPLICATION_STATE_WITH_MULTIPLE_SERVERS_WALK,
 						OPERATIONAL_BEHAVIOR_PRIMARY_APPLICATION_STATE_WITH_MULTIPLE_SERVERS_WALK);
 			}
-		} else if (topic.equals(Constants.TOPIC_ROOT_SP_BV_1_0 + "/" + groupId + "/" + Constants.TOPIC_PATH_DDEATH + "/"
+		} else if (deviceId != null && topic.equals(Constants.TOPIC_ROOT_SP_BV_1_0 + "/" + groupId + "/" + Constants.TOPIC_PATH_DDEATH + "/"
 				+ edgeNodeId + "/" + deviceId)) {
 
 			if (state == TestStatus.ENDING) {
@@ -460,13 +485,13 @@ public class MultipleBrokerTest extends TCKTest {
 			if (topic.equals(Constants.TOPIC_ROOT_SP_BV_1_0 + "/" + groupId + "/" + Constants.TOPIC_PATH_NBIRTH + "/"
 					+ edgeNodeId)) {
 				nbirth_found = true;
-			} else if (topic.equals(Constants.TOPIC_ROOT_SP_BV_1_0 + "/" + groupId + "/" + Constants.TOPIC_PATH_DBIRTH
+			} else if (deviceId != null && topic.equals(Constants.TOPIC_ROOT_SP_BV_1_0 + "/" + groupId + "/" + Constants.TOPIC_PATH_DBIRTH
 					+ "/" + edgeNodeId + "/" + deviceId)) {
 				dbirth_found = true;
 			}
 			msg = broker2.getNextMessage();
 		}
-		Utils.setResultIfNotFail(testResults, nbirth_found && dbirth_found,
+		Utils.setResultIfNotFail(testResults, nbirth_found && (deviceId == null || dbirth_found),
 				ID_OPERATIONAL_BEHAVIOR_PRIMARY_APPLICATION_STATE_WITH_MULTIPLE_SERVERS_WALK,
 				OPERATIONAL_BEHAVIOR_PRIMARY_APPLICATION_STATE_WITH_MULTIPLE_SERVERS_WALK);
 	}

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/PrimaryHostTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/PrimaryHostTest.java
@@ -99,10 +99,10 @@ public class PrimaryHostTest extends TCKTest {
 	private final @NotNull TCK theTCK;
 	private final ManagedExtensionExecutorService executorService = Services.extensionExecutorService();
 
-	private @NotNull String deviceId;
-	private @NotNull String groupId;
-	private @NotNull String edgeNodeId;
-	private @NotNull String hostApplicationId;
+	private @NotNull String deviceId = null;
+	private @NotNull String groupId = null;
+	private @NotNull String edgeNodeId = null;
+	private @NotNull String hostApplicationId = null;
 	private @NotNull long seqUnassigned = -1;
 	private @NotNull long birthSeq = -1; // record the nbirth seq to check for matching ndeath
 	private Utilities utilities = null;
@@ -110,19 +110,21 @@ public class PrimaryHostTest extends TCKTest {
 	private TestStatus state = TestStatus.NONE;
 
 	public PrimaryHostTest(TCK aTCK, Utilities utilities, String[] parms, Results.Config config) {
-		logger.info("Edge Node payload validation test. Parameters: {} ", Arrays.asList(parms));
+		logger.info("Edge Node Primary Host test. Parameters: {} ", Arrays.asList(parms));
 		theTCK = aTCK;
 		this.utilities = utilities;
 
-		if (parms.length < 4) {
+		if (parms.length < 3) {
 			log("Not enough parameters: " + Arrays.toString(parms));
-			log("Parameters to edge primary host test must be: hostId groupId edgeNodeId deviceId");
+			log("Parameters to edge primary host test must be: hostId groupId edgeNodeId {deviceId}");
 			throw new IllegalArgumentException();
 		}
 		hostApplicationId = parms[0];
 		groupId = parms[1];
 		edgeNodeId = parms[2];
-		deviceId = parms[3];
+		if (parms.length == 4) {
+			deviceId = parms[3];
+		}
 		logger.info("Parameters are HostId: {}, GroupId: {}, EdgeNodeId: {}, DeviceId: {}", hostApplicationId, groupId,
 				edgeNodeId, deviceId);
 

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/ReceiveCommandTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/ReceiveCommandTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Ian Craggs
+ * Copyright (c) 2021, 2024 Ian Craggs
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -105,13 +105,13 @@ public class ReceiveCommandTest extends TCKTest {
 			ID_OPERATIONAL_BEHAVIOR_DATA_COMMANDS_REBIRTH_ACTION_2,
 			ID_OPERATIONAL_BEHAVIOR_DATA_COMMANDS_REBIRTH_ACTION_3, ID_PAYLOADS_NDEATH_WILL_MESSAGE);
 
-	private @NotNull TestStatus state;
-	private @NotNull String deviceId;
-	private @NotNull String groupId;
-	private @NotNull String edgeNodeId;
-	private @NotNull String hostApplicationId;
+	private @NotNull TestStatus state = null;
+	private @NotNull String deviceId = null;
+	private @NotNull String groupId = null;
+	private @NotNull String edgeNodeId = null;
+	private @NotNull String hostApplicationId = null;
 	private @NotNull long deathBdSeq = -1;
-	private String edgeNodeClientId;
+	private String edgeNodeClientId = null;
 	private boolean bNBirth = false, bDBirth = false;
 	private PublishService publishService = Services.publishService();
 	private final ManagedExtensionExecutorService executorService = Services.extensionExecutorService();
@@ -124,9 +124,9 @@ public class ReceiveCommandTest extends TCKTest {
 		theTCK = aTCK;
 		this.utilities = utilities;
 
-		if (params.length < 4) {
+		if (params.length < 3) {
 			log("Not enough parameters: " + Arrays.toString(params));
-			log("Parameters to edge receive command test must be: hostApplicationId groupId edgeNodeId deviceId");
+			log("Parameters to edge receive command test must be: hostApplicationId groupId edgeNodeId {deviceId}");
 			throw new IllegalArgumentException();
 		}
 		state = TestStatus.NONE;
@@ -134,7 +134,9 @@ public class ReceiveCommandTest extends TCKTest {
 		hostApplicationId = params[0];
 		groupId = params[1];
 		edgeNodeId = params[2];
-		deviceId = params[3];
+		if (params.length == 4) {
+			deviceId = params[3];
+		}
 		logger.info("Host application id: {}, Group id: {}, Edge node id: {}, Device id: {}", hostApplicationId,
 				groupId, edgeNodeId, deviceId);
 
@@ -314,8 +316,13 @@ public class ReceiveCommandTest extends TCKTest {
 
 		if (state == TestStatus.EXPECT_NODE_BIRTH
 				&& topic.equals(TOPIC_ROOT_SP_BV_1_0 + "/" + groupId + "/" + TOPIC_PATH_NBIRTH + "/" + edgeNodeId)) {
-			log("Edge " + edgeNodeId + " is now online");
-			state = TestStatus.EXPECT_DEVICE_BIRTH;
+			if (deviceId == null) {
+				log("Edge " + edgeNodeId + " is now online, sending rebirth");
+				sendRebirth(true);
+			} else {
+				log("Edge " + edgeNodeId + " is now online");
+				state = TestStatus.EXPECT_DEVICE_BIRTH;
+			}
 		} else if (state == TestStatus.EXPECT_DEVICE_BIRTH && topic.equals(
 				TOPIC_ROOT_SP_BV_1_0 + "/" + groupId + "/" + TOPIC_PATH_DBIRTH + "/" + edgeNodeId + "/" + deviceId)) {
 			log("Device " + deviceId + " is now online, sending rebirth");
@@ -343,7 +350,7 @@ public class ReceiveCommandTest extends TCKTest {
 									deathBdSeq, birthSeq);
 						}
 					}
-				} else if (levels.length == 5 && levels[2].equals(TOPIC_PATH_DBIRTH)) {
+				} else if (levels.length == 5 && levels[2].equals(TOPIC_PATH_DBIRTH) && levels[4].equals(deviceId)) {
 					log("Device birth received for device: " + levels[4]);
 					bDBirth = true;
 
@@ -363,7 +370,7 @@ public class ReceiveCommandTest extends TCKTest {
 							setResult(false, OPERATIONAL_BEHAVIOR_DATA_COMMANDS_REBIRTH_ACTION_1));
 				}
 
-				if (bNBirth && bDBirth && state == TestStatus.SENDING_NODE_REBIRTH) {
+				if (bNBirth && (deviceId == null || bDBirth) && state == TestStatus.SENDING_NODE_REBIRTH) {
 					logger.debug(
 							"Check Req: {} After an Edge Node stops sending DATA messages, it MUST send a complete BIRTH sequence including the NBIRTH and DBIRTH(s) if applicable.",
 							ID_OPERATIONAL_BEHAVIOR_DATA_COMMANDS_REBIRTH_ACTION_2);

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendDataTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SendDataTest.java
@@ -172,15 +172,17 @@ public class SendDataTest extends TCKTest {
 		this.utilities = utilities;
 		this.config = config;
 
-		if (params.length < 3) {
+		if (params.length < 2) {
 			log("Not enough parameters: " + Arrays.toString(params));
-			log("Parameters to send data test must be: groupId edgeNodeId deviceId");
+			log("Parameters to send data test must be: hostApplicationId groupId edgeNodeId {deviceId}");
 			throw new IllegalArgumentException();
 		}
 		hostApplicationId = params[0];
 		groupId = params[1];
 		edgeNodeId = params[2];
-		deviceId = params[3];
+		if (params.length == 4) {
+			deviceId = params[3];
+		}
 		logger.info("Parameters are Host application ID: {}, GroupId: {}, EdgeNodeId: {}, DeviceId: {}",
 				hostApplicationId, groupId, edgeNodeId, deviceId);
 
@@ -285,7 +287,7 @@ public class SendDataTest extends TCKTest {
 			checkDDATA(clientId, packet);
 		}
 
-		if (isEdgeNodeChecked && isDeviceChecked) {
+		if (isEdgeNodeChecked && (deviceId == null || isDeviceChecked)) {
 			theTCK.endTest();
 		}
 	}

--- a/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SessionTerminationTest.java
+++ b/tck/src/main/java/org/eclipse/sparkplug/tck/test/edge/SessionTerminationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Ian Craggs
+ * Copyright (c) 2022, 2024 Ian Craggs
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -107,7 +107,7 @@ public class SessionTerminationTest extends TCKTest {
 	private @NotNull String hostApplicationId;
 	private @NotNull String groupId;
 	private @NotNull String edgeNodeId;
-	private @NotNull String deviceId;
+	private @NotNull String deviceId = null;
 
 	private @NotNull boolean ndeathFound = false;
 	private @NotNull boolean ddeathFound = false;
@@ -121,16 +121,18 @@ public class SessionTerminationTest extends TCKTest {
 		theTCK = aTCK;
 		this.utilities = utilities;
 
-		if (parms.length < 4) {
+		if (parms.length < 3) {
 			log("Not enough parameters: " + Arrays.toString(parms));
-			log("Parameters to edge session termination test must be: hostApplicationId groupId edgeNodeId deviceId");
+			log("Parameters to edge session termination test must be: hostApplicationId groupId edgeNodeId {deviceId}");
 			throw new IllegalArgumentException();
 		}
 
 		hostApplicationId = parms[0];
 		groupId = parms[1];
 		edgeNodeId = parms[2];
-		deviceId = parms[3];
+		if (parms.length == 4) {
+			deviceId = parms[3];
+		}
 
 		logger.info("Host application id: {}, Group id: {}, Edge node id: {}, Device id: {}", hostApplicationId,
 				groupId, edgeNodeId, deviceId);
@@ -256,6 +258,7 @@ public class SessionTerminationTest extends TCKTest {
 		if (disconnected && ndeathFound) {
 			theTCK.endTest();
 		}
+		logger.info("Disconnected: {}, ndeathFound: {}", disconnected, ndeathFound);
 	}
 
 	@Override
@@ -305,7 +308,7 @@ public class SessionTerminationTest extends TCKTest {
 		logger.info("Edge session termination test - publish - to topic: {} ", packet.getTopic());
 
 		if (testClientId == null || !clientId.equals(testClientId)) {
-			// ignore disconnect packets from other clients
+			// ignore packets from other clients
 			return;
 		}
 
@@ -363,8 +366,11 @@ public class SessionTerminationTest extends TCKTest {
 			testResults.put(ID_PAYLOADS_DDEATH_SEQ_NUMBER, setResult(payload.hasSeq(), PAYLOADS_DDEATH_SEQ_NUMBER));
 		}
 
-		if (disconnected && ndeathFound && ddeathFound) {
+		// if there is no device id, don't wait for a NDEATH
+		if (disconnected && ndeathFound && (deviceId == null || ddeathFound)) {
 			theTCK.endTest();
 		}
+		logger.info("Disconnected: {}, ndeathFound: {}, deviceId: {}, ddeathFound: {}", disconnected,
+				ndeathFound, deviceId, ddeathFound);
 	}
 }

--- a/tck/webconsole/components/Tck/Tests.vue
+++ b/tck/webconsole/components/Tck/Tests.vue
@@ -1,5 +1,5 @@
 <!--****************************************************************************
- * Copyright (c) 2021, 2023 Lukas Brand, Ian Craggs
+ * Copyright (c) 2021, 2024 Lukas Brand, Ian Craggs
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -510,20 +510,21 @@ export default {
                         name: "SessionEstablishmentTest",
                         readableName: "Session Establishment Test",
                         description: `This test checks that Edge Nodes and Devices can connect correctly to the MQTT broker.
-                        It can be run in two ways, with a real Host Application or simulated. To use a real Host Application, 
-                        ensure it is active before the test is started.`,
+                        It can be run with either a real or simulated Host Application. To use a real Host Application, 
+                        ensure the Host Application is online before the test is started.
+                        Devices are optional, but you must enter their Sparkplug IDs for them to be tested.`,
                         requirements: [
                             "Connect this console to the HiveMQ broker.",
-                            "Set the Host App, Group, Edge Node and Device ids.",
+                            "Set the Host App, Group, Edge Node and optionally Device ids.",
                             "Ensure the Host App is started, if you are using a real one.",
                             "Start this test.",
-                            "Connect the Edge Node and Device.",
+                            "Connect the Edge Node (and Devices).",
                             "Wait until the test is finished and check the results.",
                             "If the test does not stop automatically, press the \"Stop Test\" button."
                         ],
                         parameters: {
                             device_ids: {
-                                parameterReadableName: "Device Ids",
+                                parameterReadableName: "Device Ids (optional)",
                                 parameterValue: "",
                                 parameterDescription: "The space separated list of Ids of devices connected to the edge node.",
                             },
@@ -540,20 +541,21 @@ export default {
                         description: `This is the Sparkplug Edge Node session termination test.
                         It tests deliberate session termination, where NDEATH and DDEATH
                         packets are sent before disconnecting. A simulated Host Application will
-                        be used if the named one is not already connected. `,
+                        be used if the named one is not already connected. 
+                        Devices are optional, but you must enter their Sparkplug IDs for them to be tested.`,
                         requirements: [
                             "Connect this console to the HiveMQ broker.",
-                            "Set the Device Id that is used by the configured Host, Group and Edge.",
+                            "Set a Device Id if used by the configured Host, Group and Edge.",
                             "Connect the Host Application to the broker, if you are using one.",
                             "Start this test.",
-                            "Connect the Edge Node and Device.",
-                            "Stop the edge node and device named.",
+                            "Connect the Edge Node (and Device).",
+                            "Stop the edge node (and device) named.",
                             "Wait until the test is finished and check the results.",
                             "If the test does not stop automatically, press the \"Stop Test\" button."
                         ],
                         parameters: {
                             device_ids: {
-                                parameterReadableName: "Device Ids",
+                                parameterReadableName: "Device Ids (optional)",
                                 parameterValue: "",
                                 parameterDescription: "The space separated list of Ids of devices connected to the edge node.",
                             },
@@ -568,12 +570,12 @@ export default {
                         name: "SendDataTest",
                         readableName: "Send Data Test",
                         description: `This is the Edge Node Sparkplug send data test.
-                            It determines the MQTT client ID of the Edge Node from the MQTT connect,
-                            so you must connect the Edge Node after the test has started.
-                        `,
+                        It determines the MQTT client ID of the Edge Node from the MQTT connect,
+                        so you must connect the Edge Node after the test has started.
+                        A device is optional, but you must enter its Sparkplug ID for it to be tested.`,
                         requirements: [
                             "Connect this console to the HiveMQ broker.",
-                            "Set Device Id that is used by the configured Group and Edge.",
+                            "Set Device Id if used by the configured Group and Edge.",
                             "Ensure the Edge Node is not connected to the broker.",
                             "Start this test.",
                             "Connect the Edge Node and send data from the Edge Node and Device.",
@@ -582,7 +584,7 @@ export default {
                         ],
                         parameters: {
                             device_id: {
-                                parameterReadableName: "Device Id",
+                                parameterReadableName: "Device Id (optional)",
                                 parameterValue: "",
                                 parameterDescription: "The Id of a device connected to the edge node",
                             },
@@ -600,19 +602,19 @@ export default {
                         data types: DataSets, Templates and Custom Properties. It determines the MQTT client
                         ID of the Edge Node from the MQTT connect, so you must connect the Edge Node after
                         the test has started.
-                        `,
+                        A device is optional, but you must enter its Sparkplug ID for it to be tested.`,
                         requirements: [
                             "Connect this console to the HiveMQ broker.",
-                            "Set Device Id that is used by the configured Group and Edge.",
+                            "Set Device Id if used by the configured Group and Edge.",
                             "Ensure the Edge Node is not connected to the broker.",
                             "Start this test.",
-                            "Connect the Edge Node and send data from the Edge Node and Device.",
+                            "Connect the Edge Node and send data from the Edge Node (and Device).",
                             "Wait until the test is finished and check the results.",
                             "If the test does not stop automatically, press the \"Stop Test\" button."
                         ],
                         parameters: {
                             device_id: {
-                                parameterReadableName: "Device Id",
+                                parameterReadableName: "Device Id (optional)",
                                 parameterValue: "",
                                 parameterDescription: "The Id of a device connected to the edge node",
                             },
@@ -629,10 +631,11 @@ export default {
                         description: `This is the Edge Node Sparkplug receive command test. A rebirth
                                       command will be sent to the Edge Node, and the proper rebirth
                                       sequence checked. Do not connect the Host Application and 
-                                      start the Edge node only once the test has been started.`,
+                                      start the Edge node only once the test has been started.
+                                      A device is optional, but you must enter its Sparkplug ID for it to be tested.`,
                         requirements: [
                             "Connect this console to the HiveMQ broker.",
-                            "Set Device Id that is used by the configured Group and Edge.",
+                            "Set Device Id if used by the configured Group and Edge.",
                             "Ensure the Host Application and Edge Node are not connected.",
                             "Start this test.",
                             "Start the Edge Node.",
@@ -642,7 +645,7 @@ export default {
                         ],
                         parameters: {
                             device_id: {
-                                parameterReadableName: "Device Id",
+                                parameterReadableName: "Device Id (optional)",
                                 parameterValue: "",
                                 parameterDescription: "The Id of a device connected to the edge node",
                             },
@@ -660,10 +663,11 @@ export default {
                                       Application behaves correctly. The test contains delays so can take 30 seconds
                                       or more to run.
                                       This test uses a simulated Host Application, so no Host Application should be
-                                      connected to the broker as this will confuse the test.`,
+                                      connected to the broker as this will confuse the test.
+                                      A device is optional, but you must enter its Sparkplug ID for it to be tested.`,
                         requirements: [
                             "Connect this console to the HiveMQ broker.",
-                            "Set Device Id that is used by the configured Group and Edge.",
+                            "Set Device Id if used by the configured Group and Edge.",
                             "Ensure no Host Application is connected to the HiveMQ broker.",
                             "Start the edge node to test.",
                             "Start this test.",
@@ -672,7 +676,7 @@ export default {
                         ],
                         parameters: {
                             device_id: {
-                                parameterReadableName: "Device Id",
+                                parameterReadableName: "Device Id (optional)",
                                 parameterValue: "",
                                 parameterDescription: "The Id of a device connected to the edge node",
                             },
@@ -681,7 +685,7 @@ export default {
                         logging: [],
                     },
                 },
-                multpleBrokerTest: {
+                multipleBrokerTest: {
                     testValues: {
                         testType: "EONNODE",
                         name: "MultipleBrokerTest",
@@ -689,12 +693,13 @@ export default {
                         description: `This is the Sparkplug Edge Node test. It checks that an Edge Node behaves 
                                       correctly when multiple Brokers are present. The Edge Node can be started
                                       before the test, or the test before the Edge Node, as long as no Host Application
-                                      is online. A simulated Host Application will be used.`,
+                                      is online. A simulated Host Application will be used.
+                                      A device is optional, but you must enter its Sparkplug ID for it to be tested.`,
                         requirements: [
                             "Connect this console to the HiveMQ broker.",
                             "Start a second MQTT broker listening on a different port.",
                             "Ensure no Host Application is connected to either broker.",
-                            "Set Device Id that is used by the configured Group and Edge.",
+                            "Set Device Id if used by the configured Group and Edge.",
                             "Set the broker URI of the second broker.",
                             "Start the Edge Node implementation to test.",
                             "Start this test.",
@@ -703,7 +708,7 @@ export default {
                         ],
                         parameters: {
                             device_id: {
-                                parameterReadableName: "Device Id",
+                                parameterReadableName: "Device Id (optional)",
                                 parameterValue: "",
                                 parameterDescription: "The Id of a device connected to the edge node",
                             },

--- a/tck/webconsole/pages/index.vue
+++ b/tck/webconsole/pages/index.vue
@@ -1,5 +1,5 @@
 <!--****************************************************************************
- * Copyright (c) 2021, 2023 Lukas Brand, Ian Craggs
+ * Copyright (c) 2021, 2024 Lukas Brand, Ian Craggs
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -366,9 +366,6 @@ export default {
                     } else if (!this.sparkplugClient.eonNode.edgeNodeId) {
                         alert("The Edge Node Edge Node ID parameter must be set before executing this test");
                         return;
-                    } else if (!testParameter.parameters["device_ids"].parameterValue) {
-                        alert("The Edge Node Device IDs parameter must be set before executing this test");
-                        return;
                     }
                     const testParameters =
                         this.sparkplugClient.hostApplication.hostId +
@@ -385,9 +382,6 @@ export default {
                         return;
                     } else if (!this.sparkplugClient.eonNode.edgeNodeId) {
                         alert("The Edge Node Edge Node ID parameter must be set before executing this test");
-                        return;
-                    } else if (!testParameter.parameters["device_id"].parameterValue) {
-                        alert("The Edge Node Device IDs parameter must be set before executing this test");
                         return;
                     }
                     const testParameters =
@@ -406,10 +400,10 @@ export default {
                     } else if (!this.sparkplugClient.eonNode.edgeNodeId) {
                         alert("The Edge Node Edge Node ID parameter must be set before executing this test");
                         return;
-                    } else if (!testParameter.parameters["device_id"].parameterValue) {
+                    } /*else if (!testParameter.parameters["device_id"].parameterValue) {
                         alert("The Edge Node Device ID parameter must be set before executing this test");
                         return;
-                    } else if (!testParameter.parameters["broker_uri"].parameterValue) {
+                    } */ else if (!testParameter.parameters["broker_uri"].parameterValue) {
                         alert("The Broker URI parameter must be set before executing this test");
                         return;
                     }


### PR DESCRIPTION
Yes, this is intended to fix #517. It does mean that anyone can pass the tests without having a device separate from a node, but the device specific tests would not be complete. I'll have to review the test reporting to see how that might have to change.