### PR TITLE
Various fixes and updates for Sparkplug 4.0.0

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
@@ -343,8 +343,9 @@ context of the Edge Node ID under which it exists.
 Identifies a single 'tag change event' in the Sparkplug Payload. It represents an event that 
 occurred at the Edge Node or Device such as a value or quality of a data point changing. For 
 example, it could represent the value of an analog or boolean changing at a Sparkplug Device. A 
-Sparkplug Metric typically includes a name, value, and timestamp. Sparkplug Metrics are also used in 
-NCMD and DCMD messages to send messages to Edge Nodes and Devices to change values at the Edge.
+Sparkplug Metric typically includes a name, value, quality, and timestamp. Sparkplug Metrics are
+also used in NCMD and DCMD messages to send messages to Edge Nodes and Devices to change values at
+the Edge.
 
 [[introduction_datatypes]]
 ===== Data Types

--- a/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
@@ -86,7 +86,7 @@ timer.
 === Birth and Death Certificates
 
 Birth and Death Certificates are used by both Edge Nodes and Host Applications. Death Certificates
-for both are always registered in the MQTT CONNECT packet as the MQTT Will Message. By using the
+for both, are always registered in the MQTT CONNECT packet as the MQTT Will Message. By using the
 MQTT Will message, the Death Certificates will be delivered to subscribers even if the MQTT client
 connection is lost ungracefully. For Edge Nodes, the Death Certificate uses the NDEATH Sparkplug
 verb in the topic. For Host Applications, the spBv1.0/STATE/sparkplug_host_id topic is used. More

--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -284,7 +284,7 @@ messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 * [tck-testable tck-id-topics-ndata-seq-num]#[yellow-background]*[tck-id-topics-ndata-seq-num] The
 NDATA MUST include a sequence number in the payload and it MUST have a value of one greater than the
 previous MQTT message from the Edge Node contained unless the previous MQTT message contained a
-value of 255. In this case the sequence number MUST be 0.*#
+value of 18446744073709551615 (max value of a UINT64). In this case the sequence number MUST be 0.*#
 * [tck-testable tck-id-topics-ndata-timestamp]#[yellow-background]*[tck-id-topics-ndata-timestamp] The
 NDATA MUST include a timestamp denoting the date and time the message was sent from the Edge Node.*#
 * [tck-testable tck-id-topics-ndata-payload]#[yellow-background]*[tck-id-topics-ndata-payload] The
@@ -398,7 +398,7 @@ messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 * [tck-testable tck-id-topics-dbirth-seq]#[yellow-background]*[tck-id-topics-dbirth-seq] The DBIRTH
 MUST include a sequence number in the payload and it MUST have a value of one greater than the
 previous MQTT message from the Edge Node contained unless the previous MQTT message contained a
-value of 255. In this case the sequence number MUST be 0.*#
+value of 18446744073709551615 (max value of a UINT64). In this case the sequence number MUST be 0.*#
 * [tck-testable tck-id-topics-dbirth-timestamp]#[yellow-background]*[tck-id-topics-dbirth-timestamp] The
 DBIRTH MUST include a timestamp denoting the date and time the message was sent from the Edge Node.*#
 * [tck-testable tck-id-topics-dbirth-metric-reqs]#[yellow-background]*[tck-id-topics-dbirth-metric-reqs] The
@@ -456,7 +456,7 @@ messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 * [tck-testable tck-id-topics-ddata-seq-num]#[yellow-background]*[tck-id-topics-ddata-seq-num] The
 DDATA MUST include a sequence number in the payload and it MUST have a value of one greater than the
 previous MQTT message from the Edge Node contained unless the previous MQTT message contained a
-value of 255. In this case the sequence number MUST be 0.*#
+value of 18446744073709551615 (max value of a UINT64). In this case the sequence number MUST be 0.*#
 * [tck-testable tck-id-topics-ddata-timestamp]#[yellow-background]*[tck-id-topics-ddata-timestamp] The
 DDATA MUST include a timestamp denoting the date and time the message was sent from the Edge Node.*#
 * [tck-testable tck-id-topics-ddata-payload]#[yellow-background]*[tck-id-topics-ddata-payload] The
@@ -493,7 +493,7 @@ messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 * [tck-testable tck-id-topics-ddeath-seq-num]#[yellow-background]*[tck-id-topics-ddeath-seq-num] The
 DDEATH MUST include a sequence number in the payload and it MUST have a value of one greater than
 the previous MQTT message from the Edge Node contained unless the previous MQTT message contained a
-value of 255. In this case the sequence number MUST be 0.*#
+value of 18446744073709551615 (max value of a UINT64). In this case the sequence number MUST be 0.*#
 
 [[command_dcmd]]
 ===== Command (DCMD)

--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -210,8 +210,13 @@ The NBIRTH message requires the following payload components.
 messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 * [tck-testable tck-id-topics-nbirth-seq-num]#[yellow-background]*[tck-id-topics-nbirth-seq-num] The
 NBIRTH MUST include a sequence number in the payload and it MUST have a value of 0.*#
-* [tck-testable tck-id-topics-nbirth-timestamp]#[yellow-background]*[tck-id-topics-nbirth-timestamp] The
-NBIRTH MUST include a timestamp denoting the date and time the message was sent from the Edge Node.*#
+* [tck-testable tck-id-topics-nbirth-timestamp-1]#[yellow-background]*[tck-id-topics-nbirth-timestamp-1] The
+NBIRTH MUST include the overall payload timestamp denoting the date and time the message was sent
+from the Edge Node.*#
+* [tck-testable tck-id-topics-nbirth-timestamp-2]#[yellow-background]*[tck-id-topics-nbirth-timestamp-2] Each
+individual Metric in the payload MAY include its own timestamp. If it does not, it is assumed the
+'metric value change time' is that over the overall payload timestamp included in the NBIRTH
+paylaod.*#
 * [tck-testable tck-id-topics-nbirth-metric-reqs]#[yellow-background]*[tck-id-topics-nbirth-metric-reqs] The
 NBIRTH MUST include every metric the Edge Node will ever report on.*#
 * [tck-testable tck-id-topics-nbirth-metrics]#[yellow-background]*[tck-id-topics-nbirth-metrics] At
@@ -285,8 +290,13 @@ messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 NDATA MUST include a sequence number in the payload and it MUST have a value of one greater than the
 previous MQTT message from the Edge Node contained unless the previous MQTT message contained a
 value of 18446744073709551615 (max value of a UINT64). In this case the sequence number MUST be 0.*#
-* [tck-testable tck-id-topics-ndata-timestamp]#[yellow-background]*[tck-id-topics-ndata-timestamp] The
-NDATA MUST include a timestamp denoting the date and time the message was sent from the Edge Node.*#
+* [tck-testable tck-id-topics-ndata-timestamp-1]#[yellow-background]*[tck-id-topics-ndata-timestamp-1] The
+NDATA MUST include the overall payload timestamp denoting the date and time the message was sent from
+the Edge Node.*#
+* [tck-testable tck-id-topics-ndata-timestamp-2]#[yellow-background]*[tck-id-topics-ndata-timestamp-2] Each
+individual Metric in the payload MAY include its own timestamp. If it does not, it is assumed the
+'metric value change time' is that over the overall payload timestamp included in the NDATA
+payload.*#
 * [tck-testable tck-id-topics-ndata-payload]#[yellow-background]*[tck-id-topics-ndata-payload] The
 NDATA MUST include the Edge Node’s metrics that have changed since the last NBIRTH or NDATA
 message.*#
@@ -399,8 +409,13 @@ messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 MUST include a sequence number in the payload and it MUST have a value of one greater than the
 previous MQTT message from the Edge Node contained unless the previous MQTT message contained a
 value of 18446744073709551615 (max value of a UINT64). In this case the sequence number MUST be 0.*#
-* [tck-testable tck-id-topics-dbirth-timestamp]#[yellow-background]*[tck-id-topics-dbirth-timestamp] The
-DBIRTH MUST include a timestamp denoting the date and time the message was sent from the Edge Node.*#
+* [tck-testable tck-id-topics-dbirth-timestamp-1]#[yellow-background]*[tck-id-topics-dbirth-timestamp-1] The
+DBIRTH MUST include the overall payload timestamp denoting the date and time the message was sent
+from the Edge Node.*#
+* [tck-testable tck-id-topics-dbirth-timestamp-2]#[yellow-background]*[tck-id-topics-dbirth-timestamp-2] Each
+individual Metric in the payload MAY include its own timestamp. If it does not, it is assumed the
+'metric value change time' is that over the overall payload timestamp included in the DBIRTH
+payload.*#
 * [tck-testable tck-id-topics-dbirth-metric-reqs]#[yellow-background]*[tck-id-topics-dbirth-metric-reqs] The
 DBIRTH MUST include every metric the Edge Node will ever report on.*#
 * [tck-testable tck-id-topics-dbirth-metrics]#[yellow-background]*[tck-id-topics-dbirth-metrics] At
@@ -457,8 +472,13 @@ messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 DDATA MUST include a sequence number in the payload and it MUST have a value of one greater than the
 previous MQTT message from the Edge Node contained unless the previous MQTT message contained a
 value of 18446744073709551615 (max value of a UINT64). In this case the sequence number MUST be 0.*#
-* [tck-testable tck-id-topics-ddata-timestamp]#[yellow-background]*[tck-id-topics-ddata-timestamp] The
-DDATA MUST include a timestamp denoting the date and time the message was sent from the Edge Node.*#
+* [tck-testable tck-id-topics-ddata-timestamp-1]#[yellow-background]*[tck-id-topics-ddata-timestamp-1] The
+DDATA MUST include the overall payload timestamp denoting the date and time the message was sent from
+the Edge Node.*#
+* [tck-testable tck-id-topics-ddata-timestamp-2]#[yellow-background]*[tck-id-topics-ddata-timestamp-2] Each
+individual Metric in the payload MAY include its own timestamp. If it does not, it is assumed the
+'metric value change time' is that over the overall payload timestamp included in the DDATA
+payload.*#
 * [tck-testable tck-id-topics-ddata-payload]#[yellow-background]*[tck-id-topics-ddata-payload] The
 DDATA MUST include the Device’s metrics that have changed since the last DBIRTH or DDATA message.*#
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -595,7 +595,7 @@ Server immediately after successfully subscribing its own spBv1.0/STATE/sparkplu
 * [tck-testable tck-id-host-topic-phid-birth-payload]#[yellow-background]*[tck-id-host-topic-phid-birth-payload] The
 Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where the
 one key MUST be 'online' and it's value is a boolean 'true'. The other key MUST be 'timestamp' and
-the value MUST be a numeric value representing the current UTC time in milliseconds since Epoch.*#
+the value MUST be a numeric value representing the current UTC time in nanoseconds since Epoch.*#
 * [tck-testable tck-id-host-topic-phid-birth-payload-timestamp]#[yellow-background]*[tck-id-host-topic-phid-birth-payload-timestamp] The
 timestamp metric value MUST be the same timestamp value set in the immediately prior MQTT CONNECT
 packet's Will Message payload.*#
@@ -632,7 +632,7 @@ Sparkplug Host Application MUST provide a Will message in the MQTT CONNECT packe
 * [tck-testable tck-id-host-topic-phid-death-payload]#[yellow-background]*[tck-id-host-topic-phid-death-payload] The
 STATE Death Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where
 one key MUST be 'online' and it's value is a boolean 'false'. The other key MUST be 'timestamp' and
-the value MUST be a numeric value representing the current UTC time in milliseconds since Epoch.*#
+the value MUST be a numeric value representing the current UTC time in nanoseconds since Epoch.*#
 * [tck-testable tck-id-host-topic-phid-death-payload-timestamp-connect]#[yellow-background]*[tck-id-host-topic-phid-death-payload-connect] The
 Death Certificate's used in the MQTT CONNECT packet Will message MUST use a timestamp value that
 represents the current UTC time at the time of the CONNECT packet is sent to the MQTT Server.*#

--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -82,15 +82,15 @@ The following message_type elements are defined for the Sparkplug topic namespac
 
 * *NMETA* - Metadata definition for Sparkplug Edge Nodes
 * *NBIRTH* – Birth certificate for Sparkplug Edge Nodes
+* *NREBIRTH* - Edge Node Rebirth response sent from Sparkplug Edge Nodes
 * *NDATA* – Edge Node data message
 * *NDEATH* – Death certificate for Sparkplug Edge Nodes
-* *NREBIRTH* - Edge Node Rebirth response sent from Sparkplug Edge Nodes
 
 * *DMETA* - Metadata definition for Sparkplug Devices
 * *DBIRTH* – Birth certificate for Devices
+* *DREBIRTH* - Device Rebirth response sent from Sparkplug Edge Nodes
 * *DDATA* – Device data message
 * *DDEATH* – Death certificate for Devices
-* *DREBIRTH* - Device Rebirth response sent from Sparkplug Edge Nodes
 
 * *NCMD* – Edge Node command message
 * *DCMD* – Device command message
@@ -225,12 +225,15 @@ a minimum each metric MUST include the metric name, datatype, and current value.
 Template instances will be published by this Edge Node or any devices, all Template definitions MUST
 be published in the NBIRTH.*#
 * [tck-testable tck-id-topics-nbirth-bdseq-included]#[yellow-background]*[tck-id-topics-nbirth-bdseq-included] A
-bdSeq number as a metric MUST be included in the payload.*#
+bdSeq number MUST be included in the payload.*#
 * [tck-testable tck-id-topics-nbirth-bdseq-matching]#[yellow-background]*[tck-id-topics-nbirth-bdseq-matching] This
-MUST match the bdSeq number provided in the MQTT CONNECT packet’s Will Message payload.*#
+MUST match the bdSeq number provided in the immediately prior MQTT CONNECT packet’s Will Message
+payload.*#
 ** This allows Host Applications to correlate NBIRTHs to NDEATHs.
 * [tck-testable tck-id-topics-nbirth-bdseq-increment]#[yellow-background]*[tck-id-topics-nbirth-bdseq-increment] The
-bdSeq number MUST start at zero and increment by one on every new MQTT CONNECT packet.*#
+bdSeq number MUST start at zero and increment by one on every new MQTT CONNECT packet until it
+reaches a maximum of 18446744073709551615 (max value of a UINT64). At this point, the following
+bdSeq number MUST be zero.*#
 
 The NBIRTH message can also include additional Node Control payload components. These are used by a
 Sparkplug Host Application to control aspects of the Edge Node. The following are examples of Node
@@ -245,6 +248,83 @@ list in multi-MQTT Server environments.
 ** Used by Host Application(s) to modify a poll rate on an Edge Node.
 
 The NBIRTH message can also include optional ‘Properties’ of an Edge Node. The following are
+examples of Property metrics.
+
+* Metric name: ‘Properties/Hardware Make’
+** Used to transmit the hardware manufacturer of the Edge Node
+* Metric name: ‘Properties/Hardware Model’
+** Used to transmit the hardware model of the Edge Node
+* Metric name: ‘Properties/OS’
+** Used to transmit the operating system of the Edge Node
+* Metric name: ‘Properties/OS Version’
+** Used to transmit the OS version of the Edge Node
+
+[[birth_message_nrebirth]]
+===== Birth Message (NREBIRTH)
+
+[[topics_birth_message_nrebirth]]
+====== Topic (NREBIRTH)
+
+* [tck-testable tck-id-topics-nrebirth-topic]#[yellow-background]*[tck-id-topics-nrebirth-topic] The
+Birth Certificate topic for a Sparkplug Edge Node MUST be of the form
+'namespace/group_id/NREBIRTH/edge_node_id' where the namespace is replaced with the specific
+namespace for this version of Sparkplug and the group_id and edge_node_id are replaced with the
+Group and Edge Node ID for this specific Edge Node.*#
+
+[[payloads_desc_nrebirth]]
+====== Payload (NREBIRTH)
+
+The Sparkplug Edge Node Rebirth Certificate payload contains everything required to build out a data
+structure for all metrics for this Edge Node. NREBIRTH messages are similar to NBIRTH messages but
+are a response to a specific Host Application getting 'caught up' with an Edge Node's data stream.
+The NREBIRTH message still includes all current values for all Metrics under its scope. But, it also
+has a sequence number value that will fall in line with the existing Edge Nodes data stream.
+
+The NREBIRTH message requires the following payload components.
+
+* [tck-testable tck-id-topics-nrebirth-mqtt]#[yellow-background]*[tck-id-topics-nrebirth-mqtt] NREBIRTH
+messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
+* [tck-testable tck-id-topics-nrebirth-seq-num]#[yellow-background]*[tck-id-topics-nrebirth-seq-num] The
+NREBIRTH MUST include the sequence number specified in the payload and it MUST have a value that
+lines up with the existing DATA message stream from the Edge Node.*#
+* [tck-testable tck-id-topics-nrebirth-timestamp-1]#[yellow-background]*[tck-id-topics-nrebirth-timestamp-1] The
+NREBIRTH MUST include the overall payload timestamp denoting the date and time the message was sent
+from the Edge Node.*#
+* [tck-testable tck-id-topics-nrebirth-timestamp-2]#[yellow-background]*[tck-id-topics-nrebirth-timestamp-2] Each
+individual Metric in the payload MAY include its own timestamp. If it does not, it is assumed the
+'metric value change time' is that over the overall payload timestamp included in the NREBIRTH
+paylaod.*#
+* [tck-testable tck-id-topics-nrebirth-metric-reqs]#[yellow-background]*[tck-id-topics-nrebirth-metric-reqs] The
+NREBIRTH MUST include every metric the Edge Node will ever report on.*#
+* [tck-testable tck-id-topics-nrebirth-metrics]#[yellow-background]*[tck-id-topics-nrebirth-metrics] At
+a minimum each metric MUST include the metric name, datatype, and current value.*#
+* [tck-testable tck-id-topics-nrebirth-templates]#[yellow-background]*[tck-id-topics-nrebirth-templates] If
+Template instances will be published by this Edge Node or any devices, all Template definitions MUST
+be published in the NREBIRTH.*#
+* [tck-testable tck-id-topics-nrebirth-bdseq-included]#[yellow-background]*[tck-id-topics-nrebirth-bdseq-included] A
+bdSeq number MUST be included in the payload.*#
+* [tck-testable tck-id-topics-nrebirth-bdseq-matching]#[yellow-background]*[tck-id-topics-nrebirth-bdseq-matching] This
+MUST match the bdSeq number provided in the immediately prior MQTT CONNECT packet’s Will Message
+payload.*#
+** This allows Host Applications to correlate NREBIRTHs to NDEATHs.
+* [tck-testable tck-id-topics-nrebirth-bdseq-increment]#[yellow-background]*[tck-id-topics-nrebirth-bdseq-increment] The
+bdSeq number MUST start at zero and increment by one on every new MQTT CONNECT packet until it
+reaches a maximum of 18446744073709551615 (max value of a UINT64). At this point, the following
+bdSeq number MUST be zero.*#
+
+The NREBIRTH message can also include additional Node Control payload components. These are used by
+a Sparkplug Host Application to control aspects of the Edge Node. The following are examples of Node
+Control metrics.
+
+* Metric name: ‘Node Control/Reboot’
+** Used by Host Application(s) to reboot an Edge Node.
+* Metric name: ‘Node Control/Next Server’
+** Used by Host Application(s) to request an Edge Node to walk to the next MQTT Server in its
+list in multi-MQTT Server environments.
+* Metric name: ‘Node Control/Scan Rate’
+** Used by Host Application(s) to modify a poll rate on an Edge Node.
+
+The NREBIRTH message can also include optional ‘Properties’ of an Edge Node. The following are
 examples of Property metrics.
 
 * Metric name: ‘Properties/Hardware Make’
@@ -308,10 +388,10 @@ The Death Certificate topic and payload described here are not “published” a
 client, but provided as parameters within the MQTT CONNECT control packet when this Sparkplug Edge
 Node first establishes the MQTT Client session.
 
-Immediately upon reception of an Edge Node Death Certificate (NDEATH message) with a bdSeq number
-that matches the preceding bdSeq number in the NBIRTH, any Host Application subscribed to this Edge
-Node should set the data quality of all metrics to STALE and should note the timestamp when the
-NDEATH message was received.
+Immediately upon reception of an Edge Node Death Certificate (NDEATH message) with a bdSeq number in
+this payload that matches the preceding bdSeq number in the NBIRTH, any Host Application subscribed
+to this Edge Node should set the data quality of all metrics to STALE and should note the timestamp
+when the NDEATH message was received.
 
 [[topics_death_message_ndeath]]
 ====== Topic (NDEATH)
@@ -326,18 +406,17 @@ Node ID for this specific Edge Node.*#
 ====== Payload (NDEATH)
 
 * [tck-testable tck-id-topics-ndeath-payload]#[yellow-background]*[tck-id-topics-ndeath-payload] The
-NDEATH message contains a very simple payload that MUST only include a single metric, the bdSeq
-number, so that the NDEATH event can be associated with the NBIRTH.*#
+NDEATH message contains a very simple payload that MUST only include a bdSeq number, so that the
+NDEATH event can be associated with the NBIRTH.*#
 Since this is typically published by the MQTT Server on behalf of the Edge Node, information about
 the current state of the Edge Node and its devices is not and cannot be known. As a result,
 [tck-testable tck-id-topics-ndeath-seq]#[yellow-background]*[tck-id-topics-ndeath-seq] The NDEATH
 message MUST NOT include a sequence number.*#
 
-The MQTT payload typically associated with this topic can include a Birth/Death sequence number used
-to track and synchronize Birth and Death sequences across the MQTT infrastructure. Since this
-payload will be defined in advance, and held in the MQTT server and only delivered on the
-termination of an MQTT session, not a lot of additional diagnostic information can be pre-populated
-into the payload.
+The MQTT payload associated with this topic must include a Birth/Death sequence number used to track
+and synchronize Birth and Death sequences across the MQTT infrastructure. Since this payload will be
+defined in advance, held in the MQTT server and only delivered on the termination of an MQTT
+session, not a lot of additional diagnostic information can be pre-populated into the payload.
 
 [[command_ncmd]]
 ===== Command (NCMD)
@@ -432,6 +511,71 @@ metrics.
 
 The DBIRTH message can also include optional ‘Properties’ of a device. The following are examples of 
 Property metrics.
+
+* Metric name: ‘Properties/Hardware Make’
+** Used to transmit the hardware manufacturer of the device
+* Metric name: ‘Properties/Hardware Model’
+** Used to transmit the hardware model of the device
+* Metric name: ‘Properties/FW’
+** Used to transmit the firmware version of the device
+
+[[birth_message_drebirth]]
+===== Birth Message (DREBIRTH)
+
+The Sparkplug Edge Node is responsible for the management of all attached physical and/or logical
+devices. Once the Edge Node has published its NREBIRTH, any Sparkplug Host Application ensures that
+the metric structure has the Edge Node in an 'online' state. But each physical and/or logical device
+connected to this node will still need to provide this DREBIRTH before the REBIRTH requesting Host
+Application create/update the metric structure (if this is the first time this device has been seen)
+and set any associated metrics in the application to a “*GOOD*” state.
+
+The DREBIRTH payload contains everything required to build out a data structure for all metrics for
+this device. The 'online' state of this device should be set to TRUE along with the associated
+'online' date and time this message was received by the requesting Host Application.
+
+[[topics_birth_message_drebirth]]
+====== Topic (DREBIRTH)
+
+* [tck-testable tck-id-topics-drebirth-topic]#[yellow-background]*[tck-id-topics-drebirth-topic] The
+Device Rebirth topic for a Sparkplug Device MUST be of the form
+'namespace/group_id/DBIRTH/edge_node_id/device_id' where the namespace is replaced with the specific
+namespace for this version of Sparkplug and the group_id, edge_node_id, and device_id are replaced
+with the Group, Edge Node, and Device ID for this specific Device.*#
+
+[[payloads_desc_drebirth]]
+====== Payload (DREBIRTH)
+
+The DREBIRTH message requires the following payload components.
+
+* [tck-testable tck-id-topics-drebirth-mqtt]#[yellow-background]*[tck-id-topics-drebirth-mqtt] DREBIRTH
+messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
+* [tck-testable tck-id-topics-drebirth-seq]#[yellow-background]*[tck-id-topics-drebirth-seq] The DREBIRTH
+MUST include a sequence number in the payload and it MUST have a value of one greater than the
+previous MQTT message from the Edge Node contained unless the previous MQTT message contained a
+value of 18446744073709551615 (max value of a UINT64). In this case the sequence number MUST be 0.*#
+* [tck-testable tck-id-topics-drebirth-timestamp-1]#[yellow-background]*[tck-id-topics-drebirth-timestamp-1] The
+DREBIRTH MUST include the overall payload timestamp denoting the date and time the message was sent
+from the Edge Node.*#
+* [tck-testable tck-id-topics-drebirth-timestamp-2]#[yellow-background]*[tck-id-topics-drebirth-timestamp-2] Each
+individual Metric in the payload MAY include its own timestamp. If it does not, it is assumed the
+'metric value change time' is that over the overall payload timestamp included in the DREBIRTH
+payload.*#
+* [tck-testable tck-id-topics-drebirth-metric-reqs]#[yellow-background]*[tck-id-topics-drebirth-metric-reqs] The
+DREBIRTH MUST include every metric the Edge Node will ever report on.*#
+* [tck-testable tck-id-topics-drebirth-metrics]#[yellow-background]*[tck-id-topics-drebirth-metrics] At
+a minimum each metric MUST include the metric name, metric datatype, and current value.*#
+
+The DREBIRTH message can also include optional ‘Device Control’ payload components. These are used
+by a Host Application to control aspects of a device. The following are examples of Device Control
+metrics.
+
+* Metric name: ‘Device Control/Reboot’
+** Used by Host Application(s) to reboot a device.
+* Metric name: ‘Device Control/Scan rate’
+** Used by Host Application(s) to modify a poll rate on a device.
+
+The DREBIRTH message can also include optional ‘Properties’ of a device. The following are examples
+of Property metrics.
 
 * Metric name: ‘Properties/Hardware Make’
 ** Used to transmit the hardware manufacturer of the device

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -48,7 +48,7 @@ Universal Time (UTC). In order to ensure this is the case, all Sparkplug Edge No
 Host Applications must have an accurate mechanism for ensuring their clocks remain accurate. This is
 typically left to the system operating system using technologies such as Network Time Protocol
 (NTP). Regardless of the mechanism used, ensuring all timestamps are accurate and in UTC is
-critical to all timestamps in Sparkplug.
+critical to Sparkplug operations.
 
 [[operational_behavior_case_sensitivity]]
 === Case Sensitivity in Sparkplug
@@ -289,8 +289,8 @@ show the Edge Node in an 'online' state once it publishes its NBIRTH and DBIRTH 
 Server(s), a Death Certificate (NDEATH) is issued by the MQTT Server on behalf of the Edge Node.
 Upon receipt of the Death Certificate with a bdSeq number metric that matches the preceding bdSeq
 number in the NBIRTH messages, the Primary Host Application should set the state of the Edge Node
-to ‘online=false’ and update all metric timestamps related to this Edge Node. Any defined metrics
-will be set to a STALE data quality.
+to ‘online=false’ and update all metric timestamps related to this Edge Node to 'now' using its own
+system clock. Any defined metrics will be set to a STALE data quality.
 
 .. The bdSeq number is used to correlate an NBIRTH with a NDEATH. Because the NDEATH is included in
 the MQTT CONNECT packet, its timestamp (if included) is not useful to Sparkplug Host Applications.

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -155,12 +155,17 @@ packet Will Message payload.*#
 Prior to sending an NBIRTH message, the MQTT client associated with the Edge Node must subscribe to
 receive NCMD messages with the following rules.
 
-* [tck-testable tck-id-message-flow-edge-node-ncmd-subscribe]#[yellow-background]*[tck-id-message-flow-edge-node-ncmd-subscribe] The
+* [tck-testable tck-id-message-flow-edge-node-rebirth-subscribe]#[yellow-background]*[tck-id-message-flow-edge-node-rebirth-subscribe] The
 MQTT client associated with the Edge Node MUST subscribe to a topic of the form
+'spBv1.0/group_id/REBIRTH/edge_node_id' where group_id is the Sparkplug Group ID and the edge_node_id
+is the Sparkplug Edge Node ID for this Edge Node. It MUST subscribe on this topic with a QoS of
+0.*#
+** This subscription is mandatory as Edge Nodes MUST be able to respond to 'rebirth requests'.
+* [tck-testable tck-id-message-flow-edge-node-ncmd-subscribe]#[yellow-background]*[tck-id-message-flow-edge-node-ncmd-subscribe] The
+MQTT client associated with the Edge Node SHOULD subscribe to a topic of the form
 'spBv1.0/group_id/NCMD/edge_node_id' where group_id is the Sparkplug Group ID and the edge_node_id
 is the Sparkplug Edge Node ID for this Edge Node. It MUST subscribe on this topic with a QoS of
-1.*#
-** This subscription is mandatory as Edge Nodes MUST be able to respond to 'rebirth requests'.
+0.*#
 
 After subscribing, the Edge Node must follow these additional rules.
 
@@ -946,37 +951,55 @@ Host Application will receive it without ever having received the BIRTH message(
 the Edge Node. As a result, it can send a 'Rebirth Request' using the 'REBIRTH' Sparkplug verb to
 reset its understanding of that Edge Node and become aware of all metrics associated with it.
 
-These are the rules around the 'REBIRTH' Sparkplug verb.
+These are the rules around the 'REBIRTH', 'NREBIRTH', and 'DREBIRTH' Sparkplug verbs.
 
 A 'Rebirth Request' consists of the following message from a Sparkplug Host Application with the
 following characteristics.
 
-* [tck-testable tck-id-operational-behavior-data-commands-ncmd-rebirth-verb]#[yellow-background]*[tck-id-operational-behavior-data-commands-ncmd-rebirth-verb] A
+* [tck-testable tck-id-operational-behavior-data-commands-rebirth-verb]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-verb] A
 Rebirth Request MUST use the REBIRTH Sparkplug verb.*#
-* [tck-testable tck-id-operational-behavior-data-commands-ncmd-rebirth-source]#[yellow-background]*[tck-id-operational-behavior-data-commands-ncmd-rebirth-name] A
-Rebirth Request MUST include a 'source' in the payload and it's value MUST be the Host Application's
-host_id.*#
+* [tck-testable tck-id-operational-behavior-data-commands-rebirth-source]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-name] A
+Rebirth Request MUST include a metric with the name 'source' in the payload and its value MUST be
+the Host Application's host_id.*#
 
 Upon receipt of a Rebirth Request, the Edge Node must do the following.
 
-#FIXME - everything below
-
 * [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-1]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-1] When
-an Edge Node receives a Rebirth Request, it MUST immediately stop sending DATA messages.*#
+an Edge Node receives a Rebirth Request, it MUST immediately pause sending of DATA messages.*#
 * [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-2]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-2] After
-an Edge Node stops sending DATA messages, it MUST send a complete BIRTH sequence including the
-NBIRTH and DBIRTH(s) if applicable.*#
+an Edge Node stops sending DATA messages, it MUST send a complete REBIRTH sequence including the
+NREBIRTH and DREBIRTH(s) if applicable.*#
 * [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-3]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-3] The
-NBIRTH MUST include the same bdSeq metric with the same value it had included in the Will Message
+NREBIRTH MUST include the same bdSeq metric with the same value it had included in the Will Message
 of the previous MQTT CONNECT packet.*#
 ** Because a new MQTT Session is not being established, there is no reason to update the bdSeq number
-* After the new BIRTH sequence is published, the Edge Node may continue sending DATA messages.
+* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-4]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-4] The
+NREBIRTH payload MUST use a seq number that specified to integrate into the existing DATA stream
+from the Edge Node.
+** For example, if the next pending DATA message sequence number will be 100 and the Edge Node has
+two devices, the NBIRTHs sequence number value must be 97. This means the sequence numbers will be:
+NBIRTH: 97, DBIRTH 1: 98, DBIRTH 2: 99, DATA: 100
+** This allows other host applications to continue running without being affected by another Host
+Application getting in sync with the data stream.
+* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-5]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-5] The
+NREBIRTH payload MUST account for sequence number rollover if required based on the next pending
+DATA message and the number of devices under the scope of the Edge Node.
+** For example, if the next pending DATA message sequence number will be 1 and the Edge Node has
+two devices, the NBIRTHs sequence number value must be 18446744073709551614. This means the sequence
+numbers will be: NBIRTH: 18446744073709551614, DBIRTH 1: 18446744073709551615, DBIRTH 2: 0, DATA: 1
+** The above example is based on the fact that the max value of a UINT64 is 18446744073709551615
+* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-6]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-6] Each
+DREBIRTH payload MUST use a seq number that is incremented by one from the previous message.
+* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-7]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-7] Each
+NREBIRTH  and DREBIRTH payload MUST include the current values for all metrics to properly integrate
+into the existing DATA stream.
+* After the new REBIRTH sequence is published, the Edge Node MAY continue sending DATA messages.
 
-Another common use case for sending commands is to use them to 'write' to outputs on Sparkplug
-Devices. Often these are PLCs or RTUs with writable outputs. NCMD and DCMD messages can be used for
-these writes. The general flow is for a Host Application to send a command message, the Edge Device
-receives the message and writes to the output using the native protocol. Then when the output
-changes value, it results in the Edge Node publishing a DATA message denoting the new value.
+Sparkplug commands are used to 'write' to outputs on Sparkplug Edge Nodes or Devices. Often these
+are PLCs or RTUs with writable outputs. NCMD and DCMD messages can be used for these writes. The
+general flow is for a Host Application to send a command message, the Edge Device receives the message
+and writes to the output using the native protocol. Then when the output changes value, it results
+in the Edge Node publishing a DATA message denoting the new value.
 
 For Edge Node level commands, the following rules must be followed.
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -183,8 +183,9 @@ Edge Node's MQTT Will Message's payload MUST be a Sparkplug Google Protobuf enco
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-payload-bdSeq]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-payload-bdSeq] The
 Edge Node's MQTT Will Message's payload MUST include a metric with the name of 'bdSeq', the datatype
 of INT64, and the value MUST be incremented by one from the value in the previous MQTT CONNECT
-packet unless the value would be greater than 255. If in the previous NBIRTH a value of 255 was
-sent, the next MQTT Connect packet Will Message payload bdSeq number value MUST have a value of 0.*#
+packet unless the value would be greater than 18446744073709551615 (max value of a UINT64). If in
+the previous NBIRTH a value of 18446744073709551615 was sent, the next MQTT Connect packet Will
+Message payload bdSeq number value MUST have a value of 0.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-qos]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-qos] The
 Edge Node's MQTT Will Message's MQTT QoS MUST be 1.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-will-retained]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-will-retained] The
@@ -234,9 +235,11 @@ Edge Node's NBIRTH MQTT QoS MUST be 0.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-retained]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-retained] The
 Edge Node's NBIRTH retained flag MUST be set to false.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-payload-seq]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-payload-seq] The
-Edge Node's NBIRTH payload MUST include a 'seq' number that is between 0 and 255 (inclusive).*#
+Edge Node's NBIRTH payload MUST include a 'seq' number that is between 0 and 18446744073709551615
+(inclusive).*#
 ** This will become the starting sequence number which all following messages will include a
-sequence number that is one more than the previous up to 255 where it wraps back to zero.
+sequence number that is one more than the previous up to 18446744073709551615 (max value of a
+UINT64) where it wraps back to zero.
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-phid-offline]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-phid-offline] If
 the Edge Node is configured to wait for a Primary Host Application, it is connected to the MQTT
 Server, and receives a STATE message on its configured Primary Host, the timestamp value in the
@@ -431,9 +434,9 @@ Device's DBIRTH MQTT QoS MUST be 0.*#
 * [tck-testable tck-id-message-flow-device-birth-publish-dbirth-retained]#[yellow-background]*[tck-id-message-flow-device-birth-publish-dbirth-retained] The
 Device's DBIRTH retained flag MUST be set to false.*#
 * [tck-testable tck-id-message-flow-device-birth-publish-dbirth-payload-seq]#[yellow-background]*[tck-id-message-flow-device-birth-publish-dbirth-payload-seq] The
-Device's DBIRTH payload MUST include a 'seq' number that is between 0 and 255 (inclusive) and be one
-more than was included in the prior Sparkplug message sent from the Edge Node associated with this
-Device.*#
+Device's DBIRTH payload MUST include a 'seq' number that is between 0 and 18446744073709551615
+(inclusive) and be one more than was included in the prior Sparkplug message sent from the Edge Node
+associated with this Device.*#
 
 In order to expose and populate the metrics from any device, the following simple
 session diagram outlines the requirements:

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -943,6 +943,10 @@ to consider.
 There are two types of command (CMD) verbs in Sparkplug. These are NCMD and DCMD messages which
 target Edge Nodes and Devices respectively.
 
+* [tck-testable tck-id-operational-behavior-commands-source]#[yellow-background]*[tck-id-operational-behavior-commands-source] Command
+messages MUST have the 'source' field set in the payload and it MUST have a string value
+representing the Host ID of the Sparkplug Host Application that sent the command message.*#
+
 [[operational_behavior_rebirth]]
 === Rebirth Requests
 
@@ -959,24 +963,24 @@ These are the rules around the 'REBIRTH', 'NREBIRTH', and 'DREBIRTH' Sparkplug v
 A 'Rebirth Request' consists of the following message from a Sparkplug Host Application with the
 following characteristics.
 
-* [tck-testable tck-id-operational-behavior-data-commands-rebirth-verb]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-verb] A
+* [tck-testable tck-id-operational-behavior-rebirth-verb]#[yellow-background]*[tck-id-operational-behavior-rebirth-verb] A
 Rebirth Request MUST use the REBIRTH Sparkplug verb.*#
-* [tck-testable tck-id-operational-behavior-data-commands-rebirth-source]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-name] A
-Rebirth Request MUST include a metric with the name 'source' in the payload and its value MUST be
-the Host Application's host_id.*#
+* [tck-testable tck-id-operational-behavior-rebirth-source]#[yellow-background]*[tck-id-operational-behavior-rebirth-source] The
+Rebirth Request MUST have the 'source' field set in the payload and it MUST have a string value
+representing the Host ID of the Sparkplug Host Application that sent the REBIRTH message.*#
 
 Upon receipt of a Rebirth Request, the Edge Node must do the following.
 
-* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-1]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-1] When
+* [tck-testable tck-id-operational-behavior-rebirth-action-1]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-1] When
 an Edge Node receives a Rebirth Request, it MUST immediately pause sending of DATA messages.*#
-* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-2]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-2] After
+* [tck-testable tck-id-operational-behavior-rebirth-action-2]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-2] After
 an Edge Node stops sending DATA messages, it MUST send a complete REBIRTH sequence including the
 NREBIRTH and DREBIRTH(s) if applicable.*#
-* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-3]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-3] The
+* [tck-testable tck-id-operational-behavior-rebirth-action-3]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-3] The
 NREBIRTH MUST include the same bdSeq metric with the same value it had included in the Will Message
 of the previous MQTT CONNECT packet.*#
 ** Because a new MQTT Session is not being established, there is no reason to update the bdSeq number
-* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-4]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-4] The
+* [tck-testable tck-id-operational-behavior-rebirth-action-4]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-4] The
 NREBIRTH payload MUST use a seq number that specified to integrate into the existing DATA stream
 from the Edge Node.
 ** For example, if the next pending DATA message sequence number will be 100 and the Edge Node has
@@ -984,16 +988,16 @@ two devices, the NBIRTHs sequence number value must be 97. This means the sequen
 NBIRTH: 97, DBIRTH 1: 98, DBIRTH 2: 99, DATA: 100
 ** This allows other host applications to continue running without being affected by another Host
 Application getting in sync with the data stream.
-* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-5]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-5] The
+* [tck-testable tck-id-operational-behavior-rebirth-action-5]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-5] The
 NREBIRTH payload MUST account for sequence number rollover if required based on the next pending
 DATA message and the number of devices under the scope of the Edge Node.
 ** For example, if the next pending DATA message sequence number will be 1 and the Edge Node has
 two devices, the NBIRTHs sequence number value must be 18446744073709551614. This means the sequence
 numbers will be: NBIRTH: 18446744073709551614, DBIRTH 1: 18446744073709551615, DBIRTH 2: 0, DATA: 1
 ** The above example is based on the fact that the max value of a UINT64 is 18446744073709551615
-* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-6]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-6] Each
+* [tck-testable tck-id-operational-behavior-rebirth-action-6]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-6] Each
 DREBIRTH payload MUST use a seq number that is incremented by one from the previous message.
-* [tck-testable tck-id-operational-behavior-data-commands-rebirth-action-7]#[yellow-background]*[tck-id-operational-behavior-data-commands-rebirth-action-7] Each
+* [tck-testable tck-id-operational-behavior-rebirth-action-7]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-7] Each
 NREBIRTH  and DREBIRTH payload MUST include the current values for all metrics to properly integrate
 into the existing DATA stream.
 * After the new REBIRTH sequence is published, the Edge Node MAY continue sending DATA messages.
@@ -1006,26 +1010,26 @@ in the Edge Node publishing a DATA message denoting the new value.
 
 For Edge Node level commands, the following rules must be followed.
 
-* [tck-testable tck-id-operational-behavior-data-commands-ncmd-verb]#[yellow-background]*[tck-id-operational-behavior-data-commands-ncmd-verb] An
+* [tck-testable tck-id-operational-behavior-commands-ncmd-verb]#[yellow-background]*[tck-id-operational-behavior-commands-ncmd-verb] An
 Edge Node level command MUST use the NCMD Sparkplug verb.*#
-* [tck-testable tck-id-operational-behavior-data-commands-ncmd-metric-name]#[yellow-background]*[tck-id-operational-behavior-data-commands-ncmd-metric-name] An
+* [tck-testable tck-id-operational-behavior-commands-ncmd-metric-name]#[yellow-background]*[tck-id-operational-behavior-commands-ncmd-metric-name] An
 NCMD message SHOULD include a metric name that was included in the associated NBIRTH message for the
 Edge Node.*#
 ** Sparkplug Edge Node Applications should be resilient to receiving metrics names that were not
 included in the NBIRTH message.
-* [tck-testable tck-id-operational-behavior-data-commands-ncmd-metric-value]#[yellow-background]*[tck-id-operational-behavior-data-commands-ncmd-metric-value] An
+* [tck-testable tck-id-operational-behavior-commands-ncmd-metric-value]#[yellow-background]*[tck-id-operational-behavior-commands-ncmd-metric-value] An
 NCMD message MUST include a compatible metric value for the metric name that it is writing to.*#
 ** In other words, if the metric has a datatype of a boolean the value must be true or false.
 
 For Device level commands, the following rules must be followed.
 
-* [tck-testable tck-id-operational-behavior-data-commands-dcmd-verb]#[yellow-background]*[tck-id-operational-behavior-data-commands-dcmd-verb] A
+* [tck-testable tck-id-operational-behavior-commands-dcmd-verb]#[yellow-background]*[tck-id-operational-behavior-commands-dcmd-verb] A
 Device level command MUST use the DCMD Sparkplug verb.*#
-* [tck-testable tck-id-operational-behavior-data-commands-dcmd-metric-name]#[yellow-background]*[tck-id-operational-behavior-data-commands-dcmd-metric-name] A
+* [tck-testable tck-id-operational-behavior-commands-dcmd-metric-name]#[yellow-background]*[tck-id-operational-behavior-commands-dcmd-metric-name] A
 DCMD message SHOULD include a metric name that was included in the associated DBIRTH message for the
 Device.*#
 ** Sparkplug Edge Node Applications should be resilient to receiving metrics names that were not
 included in the DBIRTH message.
-* [tck-testable tck-id-operational-behavior-data-commands-dcmd-metric-value]#[yellow-background]*[tck-id-operational-behavior-data-commands-dcmd-metric-value] A
+* [tck-testable tck-id-operational-behavior-commands-dcmd-metric-value]#[yellow-background]*[tck-id-operational-behavior-commands-dcmd-metric-value] A
 DCMD message MUST include a compatible metric value for the metric name that it is writing to.*#
 ** In other words, if the metric has a datatype of a boolean the value must be true or false.

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -181,11 +181,11 @@ Edge Node*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-payload]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-payload] The
 Edge Node's MQTT Will Message's payload MUST be a Sparkplug Google Protobuf encoded payload.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-payload-bdSeq]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-payload-bdSeq] The
-Edge Node's MQTT Will Message's payload MUST include a metric with the name of 'bdSeq', the datatype
-of INT64, and the value MUST be incremented by one from the value in the previous MQTT CONNECT
-packet unless the value would be greater than 18446744073709551615 (max value of a UINT64). If in
-the previous NBIRTH a value of 18446744073709551615 was sent, the next MQTT Connect packet Will
-Message payload bdSeq number value MUST have a value of 0.*#
+Edge Node's MQTT Will Message's payload MUST include a bdSeq number in the payload and the value
+MUST be incremented by one from the value in the previous MQTT CONNECT packet unless the value would
+be greater than 18446744073709551615 (max value of a UINT64). If in the previous NBIRTH a value of
+18446744073709551615 was sent, the next MQTT Connect packet Will Message payload bdSeq number value
+MUST have a value of 0.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-qos]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-qos] The
 Edge Node's MQTT Will Message's MQTT QoS MUST be 1.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-will-retained]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-will-retained] The
@@ -228,8 +228,8 @@ Node*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-payload]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-payload] The
 Edge Node's NBIRTH payload MUST be a Sparkplug Google Protobuf encoded payload.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-payload-bdSeq]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-payload-bdSeq] The
-Edge Node's NBIRTH payload MUST include a metric with the name of 'bdSeq' the datatype of INT64 and
-the value MUST be the same as the previous MQTT CONNECT packet.*#
+Edge Node's NBIRTH payload MUST include a bdSeq number in the payload and the value MUST be the same
+as the bdSeq number value specified in the immediately previous MQTT CONNECT packet.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-qos]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-qos] The
 Edge Node's NBIRTH MQTT QoS MUST be 0.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-retained]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-retained] The
@@ -287,19 +287,19 @@ show the Edge Node in an 'online' state once it publishes its NBIRTH and DBIRTH 
 
 . If at any point in time the Edge Node MQTT Client loses connectivity to the defined MQTT
 Server(s), a Death Certificate (NDEATH) is issued by the MQTT Server on behalf of the Edge Node.
-Upon receipt of the Death Certificate with a bdSeq number metric that matches the preceding bdSeq
-number in the NBIRTH messages, the Primary Host Application should set the state of the Edge Node
-to ‘online=false’ and update all metric timestamps related to this Edge Node to 'now' using its own
+Upon receipt of the Death Certificate with a bdSeq number that matches the preceding bdSeq number in
+the NBIRTH messages, the Primary Host Application should set the state of the Edge Node to
+‘online=false’ and update all metric timestamps related to this Edge Node to 'now' using its own
 system clock. Any defined metrics will be set to a STALE data quality.
 
 .. The bdSeq number is used to correlate an NBIRTH with a NDEATH. Because the NDEATH is included in
 the MQTT CONNECT packet, its timestamp (if included) is not useful to Sparkplug Host Applications.
-Instead, a bdSeq number must be included as a metric in the payload of the NDEATH. The same bdSeq
-number metric value must also be included in the NBIRTH message published immediately after the MQTT
-CONNECT. This allows Host Applications to know that a NDEATH matches a specific NBIRTH message. This
-is required because timing with Will Messages may result in NDEATH messages arriving after a
-new/next NBIRTH message. The bdSeq number allows Host Applications to know when it must consider the
-Edge Node offline.
+Instead, a bdSeq number must be included in the payload of the NDEATH. The same bdSeq number value
+must also be included in the NBIRTH message payload published immediately after the MQTT CONNECT.
+This allows Host Applications to know that a NDEATH matches a specific NBIRTH message. This is
+required because timing with Will Messages may result in NDEATH messages arriving after a new/next
+NBIRTH message. The bdSeq number allows Host Applications to know when it must consider the Edge
+Node offline.
 
 [[operational_behavior_edge_node_session_termination]]
 === Edge Node Session Termination
@@ -977,8 +977,8 @@ an Edge Node receives a Rebirth Request, it MUST immediately pause sending of DA
 an Edge Node stops sending DATA messages, it MUST send a complete REBIRTH sequence including the
 NREBIRTH and DREBIRTH(s) if applicable.*#
 * [tck-testable tck-id-operational-behavior-rebirth-action-3]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-3] The
-NREBIRTH MUST include the same bdSeq metric with the same value it had included in the Will Message
-of the previous MQTT CONNECT packet.*#
+NREBIRTH MUST include the same bdSeq number in the payload with the same value it had included in
+the Will Message of the immediately previous MQTT CONNECT packet.*#
 ** Because a new MQTT Session is not being established, there is no reason to update the bdSeq number
 * [tck-testable tck-id-operational-behavior-rebirth-action-4]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-4] The
 NREBIRTH payload MUST use a seq number that specified to integrate into the existing DATA stream

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -642,7 +642,7 @@ Application DEATH Certificate that indicates STATE is online=false with the mess
 to true in the MQTT Will Message. Then the Primary Host Application BIRTH Certificate must be
 published with a STATE payload of online=true. In both of these messages the timestamp value must
 match each other and represent the current connection time. The timestamp value must be a JSON
-number and represent the number of UTC milliseconds since Epoch.
+number and represent the number of UTC nanoseconds since Epoch.
 
 . As the Edge Node walks its available MQTT Server list, it will establish an MQTT Session with a
 server that has a STATE message with a JSON payload that has online=true. The Edge Node can stay
@@ -814,7 +814,7 @@ host_id is the unique identifier of the Sparkplug Host Application.*#
 Death Certificate Payload registered as the MQTT Will Message in the MQTT CONNECT packet MUST be
 JSON UTF-8 data. It MUST include two key/value pairs where one key MUST be 'online' and it's value
 is a boolean 'false'. The other key MUST be 'timestamp' and the value MUST be a numeric value
-representing the current UTC time in milliseconds since Epoch.*#
+representing the current UTC time in nanoseconds since Epoch.*#
 * [tck-testable tck-id-operational-behavior-host-application-death-qos]#[yellow-background]*[tck-id-operational-behavior-host-application-death-qos] The
 Sparkplug Host Application's Death MQTT QoS MUST be 1 (at least once).*#
 * [tck-testable tck-id-operational-behavior-host-application-death-retained]#[yellow-background]*[tck-id-operational-behavior-host-application-death-retained] The

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -299,9 +299,9 @@ message Payload {
 
     message Metric {
 
-        optional string   name          = 1;        // Metric name - should only be included on birth
-        optional uint64   alias         = 2;        // Metric alias - tied to name on birth and included in all later DATA messages
-        optional uint64   timestamp     = 3;        // Timestamp associated with data acquisition time
+        optional string   name          = 1;        // Metric name - Required in BIRTH messages, optional in DATA messages if using aliases
+        optional uint64   alias         = 2;        // Metric alias - tied to name on BIRTH and included in all later DATA messages
+        optional uint64   timestamp     = 3;        // Timestamp associated with data acquisition time - if omitted, the overall payload timestamp is assumed as the data acquisition time
         optional uint32   datatype      = 4;        // DataType of the metric/tag value
         optional bool     is_historical = 5;        // If this is historical data and should not update real time tag
         optional bool     is_transient  = 6;        // Tells consuming clients such as MQTT Engine to not store this as a tag
@@ -407,9 +407,9 @@ following definitions explain the components that make up a payload.
 ==== Payload
 
 A Sparkplug B payload is the top-level component that is encoded and used in an MQTT message. It
-contains some basic information such as a timestamp and a sequence number as well as an array of
-metrics which contain key/value pairs of data. A Sparkplug B payload includes the following
-components.
+contains some basic information such as an overall payload timestamp and a sequence number as well
+as an array of metrics which contain key/value pairs of data. A Sparkplug B payload includes the
+following components.
 
 * *payload*
 ** _timestamp_
@@ -477,13 +477,20 @@ DDATA, NCMD, and DCMD messages MUST only include an alias and the metric name MU
 ** This is the timestamp in the form of an unsigned 64-bit integer representing the number of
 milliseconds since epoch (Jan 1, 1970).
 ** [tck-testable tck-id-payloads-name-birth-data-requirement]#[yellow-background]*[tck-id-payloads-name-birth-data-requirement] The
-timestamp MUST be included with every metric in all NBIRTH, DBIRTH, NDATA, and DDATA messages.*#
+timestamp MAY be included with every metric in all NBIRTH, DBIRTH, NDATA, and DDATA messages.*#
+*** If the timestamp is omitted from the Metric definition, the overall payload timestamp MUST be
+assumed as the data acquisition time.
+*** Non-normative comment: This timestamp represents the time at which the value of a metric was
+acquired for message types of NBIRTH, NREBIRTH, NDATA, NBIRTH, DREBIRTH, and DDATA.
 ** [tck-testable tck-id-payloads-name-cmd-requirement]#[yellow-background]*[tck-id-payloads-name-cmd-requirement] The
 timestamp MAY be included with metrics in NCMD and DCMD messages.*#
-** [tck-testable tck-id-payloads-metric-timestamp-in-UTC]#[yellow-background]*[tck-id-payloads-metric-timestamp-in-UTC] The
-timestamp MUST be in UTC.*#
+*** If the timestamp is omitted from the Metric definition, the overall payload timestamp MUST be
+assumed as the write time.
 *** Non-normative comment: This timestamp represents the time at which the value of a metric was
-captured.
+written to on the Host Application for NCMD and DCMD messages.
+** [tck-testable tck-id-payloads-metric-timestamp-in-UTC]#[yellow-background]*[tck-id-payloads-metric-timestamp-in-UTC] The
+timestamp MUST be in UTC if it is included.*#
+
 * *datatype*
 ** [tck-testable tck-id-payloads-metric-datatype-value-type]#[yellow-background]*[tck-id-payloads-metric-datatype-value-type] The
 datatype MUST be an unsigned 32-bit integer representing the datatype.*#
@@ -1066,7 +1073,7 @@ subsequently sent for that given MQTT Session. These are can be found in the
 link:#operational_behavior_edge_node_session_establishment[Edge Node Session Establishment Section]
 
 * [tck-testable tck-id-payloads-nbirth-timestamp]#[yellow-background]*[tck-id-payloads-nbirth-timestamp] NBIRTH
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-nbirth-edge-node-descriptor]#[yellow-background]*[tck-id-payloads-nbirth-edge-node-descriptor] Every
 Edge Node Descriptor in any Sparkplug infrastructure MUST be unique in the system.*#
@@ -1182,7 +1189,7 @@ subsequently sent for that given MQTT Session. These are can be found in the
 link:#operational_behavior_edge_node_session_establishment[Edge Node Session Establishment Section]
 
 * [tck-testable tck-id-payloads-nrebirth-timestamp]#[yellow-background]*[tck-id-payloads-nrebirth-timestamp] NREBIRTH
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-nrebirth-edge-node-descriptor]#[yellow-background]*[tck-id-payloads-nrebirth-edge-node-descriptor] Every
 Edge Node Descriptor in any Sparkplug infrastructure MUST be unique in the system.*#
@@ -1301,7 +1308,7 @@ The DBIRTH is responsible for informing the Host Application of all of the infor
 device. This includes every metric it will publish data for in the future.
 
 * [tck-testable tck-id-payloads-dbirth-timestamp]#[yellow-background]*[tck-id-payloads-dbirth-timestamp] DBIRTH
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-dbirth-seq]#[yellow-background]*[tck-id-payloads-dbirth-seq] Every
 DBIRTH message MUST include a sequence number.*#
@@ -1423,7 +1430,7 @@ The DREBIRTH is responsible for informing a Host Application that is requesting 
 the information about the device. This includes every metric it will publish data for in the future.
 
 * [tck-testable tck-id-payloads-drebirth-timestamp]#[yellow-background]*[tck-id-payloads-drebirth-timestamp] DREBIRTH
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-drebirth-seq]#[yellow-background]*[tck-id-payloads-drebirth-seq] Every
 DREBIRTH message MUST include a sequence number.*#
@@ -1550,7 +1557,7 @@ an ordered List of metrics, multiple different change events for multiple differ
 be included in a single NDATA message.
 
 * [tck-testable tck-id-payloads-ndata-timestamp]#[yellow-background]*[tck-id-payloads-ndata-timestamp] NDATA
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-ndata-seq]#[yellow-background]*[tck-id-payloads-ndata-seq] Every
 NDATA message MUST include a sequence number.*#
@@ -1608,7 +1615,7 @@ multiple different change events for multiple different metrics can all be inclu
 DDATA message.
 
 * [tck-testable tck-id-payloads-ddata-timestamp]#[yellow-background]*[tck-id-payloads-ddata-timestamp] DDATA
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-ddata-seq]#[yellow-background]*[tck-id-payloads-ddata-seq] Every
 DDATA message MUST include a sequence number.*#
@@ -1663,7 +1670,7 @@ metric.
 REBIRTH messages are used by Host Applications to resync with an Edge Nodes existing data stream.
 
 * [tck-testable tck-id-payloads-rebirth-timestamp]#[yellow-background]*[tck-id-payloads-rebirth-timestamp] REBIRTH
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-rebirth-seq]#[yellow-background]*[tck-id-payloads-rebirth-seq] Every
 REBIRTH message MUST NOT include a sequence number.*#
@@ -1711,7 +1718,7 @@ NCMD messages are used by Host Applications to write to Edge Node outputs and se
 commands to Edge Nodes. Multiple metrics can be supplied in a single NCMD message.
 
 * [tck-testable tck-id-payloads-ncmd-timestamp]#[yellow-background]*[tck-id-payloads-ncmd-timestamp] NCMD
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-ncmd-seq]#[yellow-background]*[tck-id-payloads-ncmd-seq] Every NCMD
 message MUST NOT include a sequence number.*#
@@ -1755,7 +1762,7 @@ DCMD messages are used by Host Applications to write to device outputs and send 
 commands to devices. Multiple metrics can be supplied in a single DCMD message.
 
 * [tck-testable tck-id-payloads-dcmd-timestamp]#[yellow-background]*[tck-id-payloads-dcmd-timestamp] DCMD
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-dcmd-seq]#[yellow-background]*[tck-id-payloads-dcmd-seq] Every DCMD
 message MUST NOT include a sequence number.*#
@@ -1879,7 +1886,7 @@ determines that a device is no longer accessible (i.e. it has turned off, stoppe
 the Edge Node should publish a DDEATH to denote that device connectivity has been lost.
 
 * [tck-testable tck-id-payloads-ddeath-timestamp]#[yellow-background]*[tck-id-payloads-ddeath-timestamp] DDEATH
-messages MUST include a payload timestamp that denotes the time at which the message was
+messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
 * [tck-testable tck-id-payloads-ddeath-seq]#[yellow-background]*[tck-id-payloads-ddeath-seq] Every
 DDEATH message MUST include a sequence number.*#

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -303,11 +303,12 @@ message Payload {
         optional uint64   alias         = 2;        // Metric alias - tied to name on BIRTH and included in all later DATA messages
         optional uint64   timestamp     = 3;        // Timestamp associated with data acquisition time - if omitted, the overall payload timestamp is assumed as the data acquisition time
         optional uint32   datatype      = 4;        // DataType of the metric/tag value
-        optional bool     is_historical = 5;        // If this is historical data and should not update real time tag
-        optional bool     is_transient  = 6;        // Tells consuming clients such as MQTT Engine to not store this as a tag
-        optional bool     is_null       = 7;        // If this is null - explicitly say so rather than using -1, false, etc for some datatypes.
-        optional MetaData metadata      = 8;        // Metadata for the payload
-        optional PropertySet properties = 9;
+        optional string   source        = 5;        // Source for CMD messages if unique to the Metric (typically for forwarded writes in CMD messages)
+        optional bool     is_historical = 6;        // If this is historical data and should not update real time tag
+        optional bool     is_transient  = 7;        // Tells consuming clients such as MQTT Engine to not store this as a tag
+        optional bool     is_null       = 8;        // If this is null - explicitly say so rather than using -1, false, etc for some datatypes.
+        optional MetaData metadata      = 9;        // Metadata for the payload
+        optional PropertySet properties = 10;
 
         oneof value {
             uint32   int_value                      = 10;
@@ -329,10 +330,11 @@ message Payload {
 
     optional uint64   timestamp     = 1;        // Timestamp at message sending time
     repeated Metric   metrics       = 2;        // Repeated forever - no limit in Google Protobufs
-    optional uint64   seq           = 3;        // Sequence number
-    optional string   uuid          = 4;        // UUID to track message type in terms of schema definitions
-    optional bytes    body          = 5;        // To optionally bypass the whole definition above
-    extensions                      6 to max;   // For third party extensions
+    optional uint64   seq           = 3;        // Message sequence number
+    optional string   source        = 4;        // Source for CMD and REBIRTH messages - the Host Application ID that sent the message
+    optional string   uuid          = 5;        // UUID to track message type in terms of schema definitions
+    optional bytes    body          = 6;        // To optionally bypass the whole definition above
+    extensions                      7 to max;   // For third party extensions
 }
 ----
 
@@ -434,6 +436,15 @@ subsequent messages after an NBIRTH from an Edge Node MUST contain a sequence nu
 continually increasing by one in each message from that Edge Node until a value of
 18446744073709551615 (max value of a UINT64) is reached. At that point, the sequence number of the
 following message MUST be zero.*#
+** _source_
+*** This is the source field which represents the Sparkplug Host Application ID of the publisher for
+NCMD, DCMD, and REBIRTH messages
+**** [tck-testable tck-id-payloads-source-always-included]#[yellow-background]*[tck-id-payloads-source-always-included] A
+source MUST be included in the payload of every NCMD, DCMD, and REBIRTH Sparkplug MQTT message from
+a Sparkplug Host Application.*#
+**** [tck-testable tck-id-payloads-source-value]#[yellow-background]*[tck-id-payloads-source-value] The
+source value, when required, MUST have a value that is the Host Application ID of the publisher of the
+message.*#
 ** _uuid_
 *** This is a field which can be used to represent a schema or some other specific form of the
 message. Example usage would be to supply a UUID which represents an encoding mechanism of the
@@ -490,7 +501,6 @@ assumed as the write time.
 written to on the Host Application for NCMD and DCMD messages.
 ** [tck-testable tck-id-payloads-metric-timestamp-in-UTC]#[yellow-background]*[tck-id-payloads-metric-timestamp-in-UTC] The
 timestamp MUST be in UTC if it is included.*#
-
 * *datatype*
 ** [tck-testable tck-id-payloads-metric-datatype-value-type]#[yellow-background]*[tck-id-payloads-metric-datatype-value-type] The
 datatype MUST be an unsigned 32-bit integer representing the datatype.*#
@@ -501,6 +511,13 @@ link:#payloads_b_datatypes[valid Sparkplug Data Types].*#
 datatype MUST be included with each metric definition in NBIRTH and DBIRTH messages.*#
 ** [tck-testable tck-id-payloads-metric-datatype-not-req]#[yellow-background]*[tck-id-payloads-metric-datatype-not-req] The
 datatype SHOULD NOT be included with metric definitions in NDATA, NCMD, DDATA, and DCMD messages.*#
+* *source*
+** This is the source field which represents the Sparkplug Host Application ID of the publisher for
+NCMD, DCMD, and REBIRTH messages if it differs from the overall payload source value. This may be
+used if the Sparkplug Host Application is forwarding writes on behalf of another Host Application.
+** [tck-testable tck-id-payloads-source-metric-included]#[yellow-background]*[tck-id-payloads-source-metric-included] A
+source MAY be included if the source for this metric value differs from the overall payload source
+value.*#
 * *is_historical*
 ** This is a Boolean flag which denotes whether this metric represents a historical value. In some
 cases, it may be desirable to send metrics after they were acquired from a device or Edge Node. This
@@ -1678,10 +1695,9 @@ REBIRTH message MUST NOT include a sequence number.*#
 messages MUST be published with the MQTT QoS set to 0.*#
 * [tck-testable tck-id-payloads-rebirth-retain]#[yellow-background]*[tck-id-payloads-rebirth-retain] REBIRTH
 messages MUST be published with the MQTT retain flag set to false.*#
-* [tck-testable tck-id-payloads-rebirth-source-metric-1]#[yellow-background]*[tck-id-payloads-rebirth-source-metric-1] REBIRTH
-messages MUST include a metric in the payload with the name of 'source', the dataType MUST be
-'String', and the value MUST be the Sparkplug Host ID of the requesting Sparkplug Host
-Application.*#
+* [tck-testable tck-id-payloads-rebirth-source]#[yellow-background]*[tck-id-payloads-rebirth-source] REBIRTH
+messages MUST have the 'source' field set in the overall message payload and it MUST have a string
+value representing the Host ID of the Sparkplug Host Application that sent the REBIRTH message.*#
 
 The following is a representation of a REBIRTH message on the topic:
 
@@ -1693,17 +1709,12 @@ spBv1.0/Sparkplug B Devices/REBIRTH/Raspberry Pi
 * The ‘Edge Node ID’ is: Raspberry Pi
 * This is an REBIRTH message based on the 'REBIRTH' Sparkplug Verb
 
-Consider the following Sparkplug B payload in the NCMD message shown above:
+Consider the following Sparkplug B payload in the REBIRTH message shown above:
 
 ----
 {
         "timestamp": 1486144502122,
-        "metrics": [{
-                "name": "source",
-                "timestamp": 1486144502122,
-                "dataType": "String",
-                "value": "IamHost"
-        }]
+        "source" : "IamHost"
 }
 ----
 
@@ -1726,6 +1737,14 @@ message MUST NOT include a sequence number.*#
 messages MUST be published with the MQTT QoS set to 0.*#
 * [tck-testable tck-id-payloads-ncmd-retain]#[yellow-background]*[tck-id-payloads-ncmd-retain] NCMD
 messages MUST be published with the MQTT retain flag set to false.*#
+* [tck-testable tck-id-payloads-ncmd-source-required]#[yellow-background]*[tck-id-payloads-ncmd-source-required] NCMD
+messages MUST include the overall payload 'source' value.*#
+* [tck-testable tck-id-payloads-ncmd-source-value]#[yellow-background]*[tck-id-payloads-ncmd-source-value] NCMD
+messages MUST have the overall payload 'source' value set to the Sparkplug Host Application ID that
+is publishing the NCMD message.*#
+* [tck-testable tck-id-payloads-ncmd-metric-source-required]#[yellow-background]*[tck-id-payloads-ncmd-metric-source-required] NCMD
+messages MAY include a metirc specific 'source' value if the Sparkplug Host Application is
+forwarding metric writes on behalf of another Host Application.*#
 
 The following is a representation of a simple NCMD message on the topic:
 
@@ -1747,7 +1766,8 @@ Consider the following Sparkplug B payload in the NCMD message shown above:
                 "timestamp": 1486144502122,
                 "dataType": "Boolean",
                 "value": true
-        }]
+        }],
+        "source": "IamHost"
 }
 ----
 
@@ -1770,6 +1790,14 @@ message MUST NOT include a sequence number.*#
 messages MUST be published with the MQTT QoS set to 0.*#
 * [tck-testable tck-id-payloads-dcmd-retain]#[yellow-background]*[tck-id-payloads-dcmd-retain] DCMD
 messages MUST be published with the MQTT retain flag set to false.*#
+* [tck-testable tck-id-payloads-dcmd-source-required]#[yellow-background]*[tck-id-payloads-dcmd-source-required] DCMD
+messages MUST include the overall payload 'source' value.*#
+* [tck-testable tck-id-payloads-dcmd-source-value]#[yellow-background]*[tck-id-payloads-dcmd-source-value] DCMD
+messages MUST have the overall payload 'source' value set to the Sparkplug Host Application ID that
+is publishing the DCMD message.*#
+* [tck-testable tck-id-payloads-dcmd-metric-source-required]#[yellow-background]*[tck-id-payloads-dcmd-metric-source-required] DCMD
+messages MAY include a metirc specific 'source' value if the Sparkplug Host Application is
+forwarding metric writes on behalf of another Host Application.*#
 
 The following is a representation of a simple DCMD message on the topic:
 
@@ -1797,7 +1825,8 @@ Consider the following Sparkplug B payload in the DCMD message shown above:
                 "timestamp": 1486144502122,
                 "dataType": "Boolean",
                 "value": true
-        }]
+        }],
+        "source": "IamHost"
 }
 ----
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -424,12 +424,13 @@ link:#payloads_b_metric[here].
 sequence number MUST be included in the payload of every Sparkplug MQTT message from an Edge Node
 except NDEATH messages.*#
 **** [tck-testable tck-id-payloads-sequence-num-req-nbirth]#[yellow-background]*[tck-id-payloads-sequence-num-zero-nbirth] A
-NBIRTH message from an Edge Node MUST always contain a sequence number between 0 and 255
-(inclusive).*#
+NBIRTH message from an Edge Node MUST always contain a sequence number between 0 and
+18446744073709551615 (inclusive).*#
 **** [tck-testable tck-id-payloads-sequence-num-incrementing]#[yellow-background]*[tck-id-payloads-sequence-num-incrementing] All
 subsequent messages after an NBIRTH from an Edge Node MUST contain a sequence number that is
-continually increasing by one in each message from that Edge Node until a value of 255 is reached.
-At that point, the sequence number of the following message MUST be zero.*#
+continually increasing by one in each message from that Edge Node until a value of
+18446744073709551615 (max value of a UINT64) is reached. At that point, the sequence number of the
+following message MUST be zero.*#
 ** _uuid_
 *** This is a field which can be used to represent a schema or some other specific form of the
 message. Example usage would be to supply a UUID which represents an encoding mechanism of the
@@ -1068,8 +1069,8 @@ published.*#
 Edge Node Descriptor in any Sparkplug infrastructure MUST be unique in the system.*#
 ** These are used like addresses and need to be unique as a result.
 * [tck-testable tck-id-payloads-nbirth-seq]#[yellow-background]*[tck-id-payloads-nbirth-seq] Every
-NBIRTH message MUST include a sequence number and it MUST have a value between 0 and 255
-(inclusive).*#
+NBIRTH message MUST include a sequence number and it MUST have a value between 0 and
+18446744073709551615 (inclusive).*#
 * [tck-testable tck-id-payloads-nbirth-bdseq]#[yellow-background]*[tck-id-payloads-nbirth-bdseq] Every
 NBIRTH message MUST include a bdSeq number metric.*#
 * [tck-testable tck-id-payloads-nbirth-bdseq-repeat]#[yellow-background]*[tck-id-payloads-nbirth-bdseq-repeat] The
@@ -1184,8 +1185,8 @@ published.*#
 Edge Node Descriptor in any Sparkplug infrastructure MUST be unique in the system.*#
 ** These are used like addresses and need to be unique as a result.
 * [tck-testable tck-id-payloads-nrebirth-seq-1]#[yellow-background]*[tck-id-payloads-nrebirth-seq-1] Every
-NREBIRTH message MUST include a sequence number and it MUST have a value between 0 and 255
-(inclusive).*#
+NREBIRTH message MUST include a sequence number and it MUST have a value between 0 and
+18446744073709551615 (inclusive).*#
 * [tck-testable tck-id-payloads-nrebirth-seq-2]#[yellow-background]*[tck-id-payloads-nrebirth-seq-2] Every
 NREBIRTH message MUST include a sequence number that is the following value:*#
 ** rsn = pds - (1 + dc)
@@ -1303,8 +1304,9 @@ published.*#
 DBIRTH message MUST include a sequence number.*#
 * [tck-testable tck-id-payloads-dbirth-seq-inc]#[yellow-background]*[tck-id-payloads-dbirth-seq-inc] Every
 DBIRTH message MUST include a sequence number value that is one greater than the previous sequence
-number sent by the Edge Node. This value MUST never exceed 255. If in the previous sequence number
-sent by the Edge Node was 255, the next sequence number sent MUST have a value of 0.*#
+number sent by the Edge Node. This value MUST never exceed 18446744073709551615 (max value of a
+UINT64). If in the previous sequence number sent by the Edge Node was 18446744073709551615, the next
+sequence number sent MUST have a value of 0.*#
 * [tck-testable tck-id-payloads-dbirth-order]#[yellow-background]*[tck-id-payloads-dbirth-order] All
 DBIRTH messages sent by an Edge Node MUST be sent immediately after the NBIRTH and before any NDATA
 or DDATA messages are published by the Edge Node.*#
@@ -1424,8 +1426,9 @@ published.*#
 DREBIRTH message MUST include a sequence number.*#
 * [tck-testable tck-id-payloads-drebirth-seq-inc]#[yellow-background]*[tck-id-payloads-drebirth-seq-inc] Every
 DREBIRTH message MUST include a sequence number value that is one greater than the previous sequence
-number sent by the Edge Node. This value MUST never exceed 255. If in the previous sequence number
-sent by the Edge Node was 255, the next sequence number sent MUST have a value of 0.*#
+number sent by the Edge Node. This value MUST never exceed 18446744073709551615 (max value of a
+UINT64). If in the previous sequence number sent by the Edge Node was 18446744073709551615, the next
+sequence number sent MUST be a value of 0.*#
 * [tck-testable tck-id-payloads-drebirth-order]#[yellow-background]*[tck-id-payloads-drebirth-order] All
 DREBIRTH messages sent by an Edge Node MUST be sent immediately after the NREBIRTH and before any
 NDATA or DDATA messages are published by the Edge Node.*#
@@ -1550,8 +1553,9 @@ published.*#
 NDATA message MUST include a sequence number.*#
 * [tck-testable tck-id-payloads-ndata-seq-inc]#[yellow-background]*[tck-id-payloads-ndata-seq-inc] Every
 NDATA message MUST include a sequence number value that is one greater than the previous sequence
-number sent by the Edge Node. This value MUST never exceed 255. If in the previous sequence number
-sent by the Edge Node was 255, the next sequence number sent MUST have a value of 0.*#
+number sent by the Edge Node. This value MUST never exceed 18446744073709551615 (max value of a
+UINT64). If in the previous sequence number sent by the Edge Node was 18446744073709551615, the next
+sequence number sent MUST have a value of 0.*#
 * [tck-testable tck-id-payloads-ndata-order]#[yellow-background]*[tck-id-payloads-ndata-order] All
 NDATA messages sent by an Edge Node MUST NOT be sent until all the NBIRTH and all DBIRTH messages
 have been published by the Edge Node.*#
@@ -1607,8 +1611,9 @@ published.*#
 DDATA message MUST include a sequence number.*#
 * [tck-testable tck-id-payloads-ddata-seq-inc]#[yellow-background]*[tck-id-payloads-ddata-seq-inc] Every
 DDATA message MUST include a sequence number value that is one greater than the previous sequence
-number sent by the Edge Node. This value MUST never exceed 255. If in the previous sequence number
-sent by the Edge Node was 255, the next sequence number sent MUST have a value of 0.*#
+number sent by the Edge Node. This value MUST never exceed 18446744073709551615 (max value of a
+UINT64). If in the previous sequence number sent by the Edge Node was 18446744073709551615, the next
+sequence number sent MUST have a value of 0.*#
 * [tck-testable tck-id-payloads-ddata-order]#[yellow-background]*[tck-id-payloads-ddata-order] All
 DDATA messages sent by an Edge Node MUST NOT be sent until all the NBIRTH and all DBIRTH messages
 have been published by the Edge Node.*#
@@ -1812,8 +1817,8 @@ message.
 ** It is important to note that any new CONNECT packet must increment the bdSeq number in the
 payload compared to what was in the previous CONNECT packet. This ensures that any Host Applications
 will be able to distinguish between current and old bdSeq numbers in the event that messages are
-delivered out of order. When incrementing the bdSeq number, if the previous value was 255, the next
-must be zero.
+delivered out of order. When incrementing the bdSeq number, if the previous value was
+18446744073709551615 (max value of a UINT64), the next value must be zero.
 * [tck-testable tck-id-payloads-ndeath-will-message-publisher]#[yellow-background]*[tck-id-payloads-ndeath-will-message-publisher] An
 NDEATH message SHOULD be published by the Edge Node before it intentionally disconnects from the
 MQTT Server.*#
@@ -1877,8 +1882,9 @@ published.*#
 DDEATH message MUST include a sequence number.*#
 * [tck-testable tck-id-payloads-ddeath-seq-inc]#[yellow-background]*[tck-id-payloads-ddeath-seq-inc] Every
 DDEATH message MUST include a sequence number value that is one greater than the previous sequence
-number sent by the Edge Node. This value MUST never exceed 255. If in the previous sequence number
-sent by the Edge Node was 255, the next sequence number sent MUST have a value of 0.*#
+number sent by the Edge Node. This value MUST never exceed 18446744073709551615 (max value of a
+UINT64). If in the previous sequence number sent by the Edge Node was 18446744073709551615, the next
+sequence number sent MUST have a value of 0.*#
 
 The following is a representation of a simple DDEATH message on the topic:
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -414,7 +414,7 @@ following components.
 * *payload*
 ** _timestamp_
 *** This is the timestamp in the form of an unsigned 64-bit integer representing the number of
-milliseconds since epoch (Jan 1, 1970).
+nanoseconds since epoch (Jan 1, 1970).
 *** [tck-testable tck-id-payloads-timestamp-in-UTC]#[yellow-background]*[tck-id-payloads-timestamp-in-UTC] This
 timestamp MUST be in UTC.*#
 *** This timestamp represents the time at which the message was published.
@@ -475,7 +475,7 @@ and DBIRTH messages MUST include both a metric name and alias.*#
 DDATA, NCMD, and DCMD messages MUST only include an alias and the metric name MUST be excluded.*#
 * *timestamp*
 ** This is the timestamp in the form of an unsigned 64-bit integer representing the number of
-milliseconds since epoch (Jan 1, 1970).
+nanoseconds since epoch (Jan 1, 1970).
 ** [tck-testable tck-id-payloads-name-birth-data-requirement]#[yellow-background]*[tck-id-payloads-name-birth-data-requirement] The
 timestamp MAY be included with every metric in all NBIRTH, DBIRTH, NDATA, and DDATA messages.*#
 *** If the timestamp is omitted from the Metric definition, the overall payload timestamp MUST be
@@ -932,7 +932,7 @@ enum DataType {
 *** Google Protocol Buffer Type: string
 *** Sparkplug enum value: 12
 * _DateTime_
-** Date time value as uint64 value representing milliseconds since epoch (Jan 1, 1970)
+** Date time value as uint64 value representing nanoseconds since epoch (Jan 1, 1970)
 ** Google Protocol Buffer Type: uint64
 ** Sparkplug enum value: 13
 * _Text_
@@ -1051,10 +1051,10 @@ ends on a byte boundary.
 *** Example (string array to Metric bytes_value): [ABC, hello] -> [0x41, 0x42, 0x43, 0x00, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00]
 ** _DateTimeArray_
 *** DateTimeArray as an array of packed little endian bytes where each Datetime value is an 8-byte
-value representing the number of milliseconds since epoch in UTC
+value representing the number of nanoseconds since epoch in UTC
 *** Google Protocol Buffer Type: bytes
 *** Sparkplug enum value: 34
-*** Example (DateTime array -> ms since epoch -> Metric bytes_value): ['Wednesday, October 21, 2009 5:27:55.335 AM', 'Friday, June 24, 2022 9:57:55 PM'] -> [1256102875335, 1656107875000] -> [0xC7, 0xD0, 0x90, 0x75, 0x24, 0x01, 0x00, 0x00, 0xB8, 0xBA, 0xB8, 0x97, 0x81, 0x01, 0x00, 0x00]
+*** Example (DateTime array -> nanoseconds since epoch -> Metric bytes_value): ['Wednesday, October 21, 2009 5:27:55.335 AM', 'Friday, June 24, 2022 9:57:55 PM'] -> [1256102875335000000, 1656107875000000000] -> [0xC0, 0x7F, 0xB0, 0xF5, 0xE8, 0x92, 0x6E, 0x11, 0x00, 0x1E, 0x1A, 0x7F, 0x56, 0xAD, 0xFB, 0x16]
 
 [[payloads_payload_representation_on_host_applications]]
 ==== Payload Representation on Host Applications
@@ -1939,7 +1939,7 @@ Sparkplug Host Application MUST set the Will Retained flag to true in the MQTT C
 * [tck-testable tck-id-payloads-state-will-message-payload]#[yellow-background]*[tck-id-payloads-state-will-message-payload] The
 Death Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where one key
 MUST be 'online' and it's value is a boolean 'false'. The other key MUST be 'timestamp' and the
-value MUST be a numeric value representing the current UTC time in milliseconds since Epoch.*#
+value MUST be a numeric value representing the current UTC time in nanoseconds since Epoch.*#
 * [tck-testable tck-id-payloads-state-subscribe]#[yellow-background]*[tck-id-payloads-state-subscribe] After
 establishing an MQTT connection, the Sparkplug Host Application MUST subscribe on it's own
 'spBv1.0/STATE/[sparkplug_host_id]' topic.*#

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -1075,15 +1075,15 @@ NBIRTH message MUST include a bdSeq number metric.*#
 * [tck-testable tck-id-payloads-nbirth-bdseq-repeat]#[yellow-background]*[tck-id-payloads-nbirth-bdseq-repeat] The
 bdSeq number value MUST match the bdSeq number value that was sent in the prior MQTT CONNECT packet
 WILL Message.*#
-** Note if a new NBIRTH is being sent (due to a Rebirth request or ant other reason) the Sparkplug
-Edge Node MQTT client MUST publish the same bdSeq number that was sent in the prior MQTT CONNECT
-packet Will Message payload. This is because the NDEATH bdSeq number MUST always match the bdSeq
-number of the associated NBIRTH that is stored in the MQTT Server via the MQTT Will Message.
+** Note if a new NBIRTH is being sent for any reason, the Sparkplug Edge Node MQTT client MUST use
+the same bdSeq number in the payload that was sent in the prior MQTT CONNECT packet Will Message
+payload. This is because the NDEATH bdSeq number MUST always match the bdSeq number of the
+associated NBIRTH that is stored in the MQTT Server via the MQTT Will Message.
 * [tck-testable tck-id-payloads-nbirth-rebirth-req]#[yellow-background]*[tck-id-payloads-nbirth-rebirth-req] Every
-NBIRTH MUST include a metric with the name 'Node Control/Rebirth' and have a boolean value of
-false.*#
-** This is used by Host Applications to force an Edge Node to send a new birth sequence (NBIRTH and
-DBIRTH messages) if errors are detected by the Host Application in the data stream.
+NBIRTH message MUST include a metric with the name 'Node Control/Rebirth' and have a boolean value
+of false.*#
+** This is used by Host Applications to force an Edge Node to send a new birth sequence (NREBIRTH
+and DREBIRTH messages) if errors are detected by a Host Application in the data stream.
 * [tck-testable tck-id-payloads-nbirth-qos]#[yellow-background]*[tck-id-payloads-nbirth-qos] NBIRTH
 messages MUST be published with the MQTT QoS set to 0.*#
 * [tck-testable tck-id-payloads-nbirth-retain]#[yellow-background]*[tck-id-payloads-nbirth-retain] NBIRTH
@@ -1103,6 +1103,129 @@ In the topic above the following information is known based on the Sparkplug top
 * This is an NBIRTH message based on the 'NBIRTH' Sparkplug Verb
 
 Consider the following Sparkplug B payload in the NBIRTH message shown above:
+
+----
+{
+        "timestamp": 1486144502122,
+        "metrics": [{
+                "name": "bdSeq",
+                "timestamp": 1486144502122,
+                "dataType": "Int64",
+                "value": 0
+        }, {
+                "name": "Node Control/Reboot",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Node Control/Rebirth",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Node Control/Next Server",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Node Control/Scan Rate",
+                "timestamp": 1486144502122,
+                "dataType": "Int64",
+                "value": 3000
+        }, {
+                "name": "Properties/Hardware Make",
+                "timestamp": 1486144502122,
+                "dataType": "String",
+                "value": "Raspberry Pi"
+        }, {
+                "name": "Properties/Hardware Model",
+                "timestamp": 1486144502122,
+                "dataType": "String",
+                "value": "Pi 3 Model B"
+        }, {
+                "name": "Properties/OS",
+                "timestamp": 1486144502122,
+                "dataType": "String",
+                "value": "Raspbian"
+        }, {
+                "name": "Properties/OS Version",
+                "timestamp": 1486144502122,
+                "dataType": "String",
+                "value": "Jessie with PIXEL/11.01.2017"
+        }, {
+                "name": "Supply Voltage",
+                "timestamp": 1486144502122,
+                "dataType": "Float",
+                "value": 12.1
+        }],
+        "seq": 0
+}
+----
+
+This would result in a structure as follows on the Host Application.
+
+.Figure 10 – Sparkplug B Metric Structure 1
+plantuml::{assetsdir}assets/plantuml/sparkplugb-metric-structure-1.puml[format=svg, alt="Sparkplug B Metric Structure 1"]
+
+[[payloads_b_nbirth]]
+==== NREBIRTH
+
+The NREBIRTH is responsible for informing a specific host application of all of the information
+about the Edge Node. This includes every metric it will publish data for in the future.
+
+There is a dependency on the MQTT CONNECT packet with regard to NREBIRTH messages that are
+subsequently sent for that given MQTT Session. These are can be found in the 
+link:#operational_behavior_edge_node_session_establishment[Edge Node Session Establishment Section]
+
+* [tck-testable tck-id-payloads-nrebirth-timestamp]#[yellow-background]*[tck-id-payloads-nrebirth-timestamp] NREBIRTH
+messages MUST include a payload timestamp that denotes the time at which the message was
+published.*#
+* [tck-testable tck-id-payloads-nrebirth-edge-node-descriptor]#[yellow-background]*[tck-id-payloads-nrebirth-edge-node-descriptor] Every
+Edge Node Descriptor in any Sparkplug infrastructure MUST be unique in the system.*#
+** These are used like addresses and need to be unique as a result.
+* [tck-testable tck-id-payloads-nrebirth-seq-1]#[yellow-background]*[tck-id-payloads-nrebirth-seq-1] Every
+NREBIRTH message MUST include a sequence number and it MUST have a value between 0 and 255
+(inclusive).*#
+* [tck-testable tck-id-payloads-nrebirth-seq-2]#[yellow-background]*[tck-id-payloads-nrebirth-seq-2] Every
+NREBIRTH message MUST include a sequence number that is the following value:*#
+** rsn = pds - (1 + dc)
+** If the rsn results in a negative number, add 18446744073709551615 (max value of a UINT64) to it.
+*** rsn = Rebirth Sequence Number value
+*** pds = Next pending DATA publish seq number
+*** dc = Device count (number of Sparkplug Devices under the scope of the Edge Node)
+* [tck-testable tck-id-payloads-nrebirth-bdseq]#[yellow-background]*[tck-id-payloads-nrebirth-bdseq] Every
+NREBIRTH message MUST include a bdSeq number metric.*#
+* [tck-testable tck-id-payloads-nrebirth-bdseq-repeat]#[yellow-background]*[tck-id-payloads-nrebirth-bdseq-repeat] The
+bdSeq number value MUST match the bdSeq number value that was sent in the prior MQTT CONNECT packet
+WILL Message.*#
+** Note if a new NREBIRTH is being sent, the Sparkplug Edge Node MQTT client MUST use the same bdSeq
+number in the payload that was sent in the prior MQTT CONNECT packet Will Message payload. This is
+because the NDEATH bdSeq number MUST always match the bdSeq number of the associated NBIRTH that is
+stored in the MQTT Server via the MQTT Will Message.
+* [tck-testable tck-id-payloads-nrebirth-rebirth-req]#[yellow-background]*[tck-id-payloads-nrebirth-rebirth-req] Every
+NREBIRTH message MUST include a metric with the name 'Node Control/Rebirth' and have a boolean value
+of false.*#
+** This is used by Host Applications to force an Edge Node to send a new birth sequence (NREBIRTH
+and DREBIRTH messages) if errors are detected by a Host Application in the data stream.
+* [tck-testable tck-id-payloads-nrebirth-qos]#[yellow-background]*[tck-id-payloads-nrebirth-qos] NREBIRTH
+messages MUST be published with the MQTT QoS set to 0.*#
+* [tck-testable tck-id-payloads-nrebirth-retain]#[yellow-background]*[tck-id-payloads-nrebirth-retain] NREBIRTH
+messages MUST be published with the MQTT retain flag set to false.*#
+
+The following is a representation of a simple NREBIRTH message on the topic:
+
+----
+spBv1.0/Sparkplug B Devices/NREBIRTH/Raspberry Pi
+----
+
+In the topic above the following information is known based on the Sparkplug topic definition:
+
+* The ‘Group ID’ is: Sparkplug B Devices
+* The ‘Edge Node ID’ is: Raspberry Pi
+* The 'Edge Node Descriptor' is the combination of the Group ID and Edge Node ID.
+* This is an NREBIRTH message based on the 'NREBIRTH' Sparkplug Verb
+
+Consider the following Sparkplug B payload in the NREBIRTH message shown above:
 
 ----
 {
@@ -1204,6 +1327,127 @@ In the topic above the following information is known based on the Sparkplug top
 * This is a DBIRTH message based on the 'DBIRTH' Sparkplug Verb
 
 Consider the following Sparkplug B payload in the DBIRTH message shown above:
+
+----
+{
+        "timestamp": 1486144502122,
+        "metrics": [{
+                "name": "Inputs/A",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Inputs/B",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Inputs/C",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Inputs/D",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Inputs/Button",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Outputs/E",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Outputs/F",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Outputs/G",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Outputs/H",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Outputs/LEDs/Green",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Outputs/LEDs/Red",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Outputs/LEDs/Yellow",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Outputs/Buzzer",
+                "timestamp": 1486144502122,
+                "dataType": "Boolean",
+                "value": false
+        }, {
+                "name": "Properties/Hardware Make",
+                "timestamp": 1486144502122,
+                "dataType": "String",
+                "value": "Pibrella"
+        }],
+        "seq": 1
+}
+----
+
+This would result in a structure as follows on the Host Application.
+
+.Figure 11 – Sparkplug B Metric Structure 2
+plantuml::{assetsdir}assets/plantuml/sparkplugb-metric-structure-2.puml[format=svg, alt="Sparkplug B Metric Structure 2"]
+
+[[payloads_b_drebirth]]
+==== DREBIRTH
+
+The DREBIRTH is responsible for informing a Host Application that is requesting a rebirth of all of
+the information about the device. This includes every metric it will publish data for in the future.
+
+* [tck-testable tck-id-payloads-drebirth-timestamp]#[yellow-background]*[tck-id-payloads-drebirth-timestamp] DREBIRTH
+messages MUST include a payload timestamp that denotes the time at which the message was
+published.*#
+* [tck-testable tck-id-payloads-drebirth-seq]#[yellow-background]*[tck-id-payloads-drebirth-seq] Every
+DREBIRTH message MUST include a sequence number.*#
+* [tck-testable tck-id-payloads-drebirth-seq-inc]#[yellow-background]*[tck-id-payloads-drebirth-seq-inc] Every
+DREBIRTH message MUST include a sequence number value that is one greater than the previous sequence
+number sent by the Edge Node. This value MUST never exceed 255. If in the previous sequence number
+sent by the Edge Node was 255, the next sequence number sent MUST have a value of 0.*#
+* [tck-testable tck-id-payloads-drebirth-order]#[yellow-background]*[tck-id-payloads-drebirth-order] All
+DREBIRTH messages sent by an Edge Node MUST be sent immediately after the NREBIRTH and before any
+NDATA or DDATA messages are published by the Edge Node.*#
+* [tck-testable tck-id-payloads-drebirth-qos]#[yellow-background]*[tck-id-payloads-drebirth-qos] DREBIRTH
+messages MUST be published with the MQTT QoS set to 0.*#
+* [tck-testable tck-id-payloads-drebirth-retain]#[yellow-background]*[tck-id-payloads-drebirth-retain] DREBIRTH
+messages MUST be published with the MQTT retain flag set to false.*#
+
+The following is a representation of a simple DREBIRTH message on the topic:
+
+----
+spBv1.0/Sparkplug B Devices/DREBIRTH/Raspberry Pi/Pibrella
+----
+
+In the topic above the following information is known based on the Sparkplug topic definition:
+
+* The ‘Group ID’ is: Sparkplug B Devices
+* The ‘Edge Node ID’ is: Raspberry Pi
+* The ‘Device ID’ is: Pibrella
+* This is a DREBIRTH message based on the 'DREBIRTH' Sparkplug Verb
+
+Consider the following Sparkplug B payload in the DREBIRTH message shown above:
 
 ----
 {
@@ -1405,6 +1649,53 @@ Consider the following Sparkplug B payload in the DDATA message shown above:
 This would result in the Host Application updating the value of the ‘Inputs/A’ metric and ‘Inputs/C’ 
 metric.
 
+[[payloads_b_rebirth]]
+==== REBIRTH
+
+REBIRTH messages are used by Host Applications to resync with an Edge Nodes existing data stream.
+
+* [tck-testable tck-id-payloads-rebirth-timestamp]#[yellow-background]*[tck-id-payloads-rebirth-timestamp] REBIRTH
+messages MUST include a payload timestamp that denotes the time at which the message was
+published.*#
+* [tck-testable tck-id-payloads-rebirth-seq]#[yellow-background]*[tck-id-payloads-rebirth-seq] Every
+REBIRTH message MUST NOT include a sequence number.*#
+* [tck-testable tck-id-payloads-rebirth-qos]#[yellow-background]*[tck-id-payloads-rebirth-qos] REBIRTH
+messages MUST be published with the MQTT QoS set to 0.*#
+* [tck-testable tck-id-payloads-rebirth-retain]#[yellow-background]*[tck-id-payloads-rebirth-retain] REBIRTH
+messages MUST be published with the MQTT retain flag set to false.*#
+* [tck-testable tck-id-payloads-rebirth-source-metric-1]#[yellow-background]*[tck-id-payloads-rebirth-source-metric-1] REBIRTH
+messages MUST include a metric in the payload with the name of 'source', the dataType MUST be
+'String', and the value MUST be the Sparkplug Host ID of the requesting Sparkplug Host
+Application.*#
+
+The following is a representation of a REBIRTH message on the topic:
+
+----
+spBv1.0/Sparkplug B Devices/REBIRTH/Raspberry Pi
+----
+
+* The ‘Group ID’ is: Sparkplug B Devices
+* The ‘Edge Node ID’ is: Raspberry Pi
+* This is an REBIRTH message based on the 'REBIRTH' Sparkplug Verb
+
+Consider the following Sparkplug B payload in the NCMD message shown above:
+
+----
+{
+        "timestamp": 1486144502122,
+        "metrics": [{
+                "name": "source",
+                "timestamp": 1486144502122,
+                "dataType": "String",
+                "value": "IamHost"
+        }]
+}
+----
+
+This REBIRTH payload tells the Edge Node to publish NREBIRTH and DREBIRTH(s) messages. This can be
+requested if a Host Application gets an out of order seq number or if a metric arrives in an NDATA
+or DDATA message that was not provided in the original NBIRTH or DBIRTH messages.
+
 [[payloads_b_ncmd]]
 ==== NCMD
 
@@ -1437,7 +1728,7 @@ Consider the following Sparkplug B payload in the NCMD message shown above:
 {
         "timestamp": 1486144502122,
         "metrics": [{
-                "name": "Node Control/Rebirth",
+                "name": "DIGITAL_OUT_1",
                 "timestamp": 1486144502122,
                 "dataType": "Boolean",
                 "value": true
@@ -1445,9 +1736,9 @@ Consider the following Sparkplug B payload in the NCMD message shown above:
 }
 ----
 
-This NCMD payload tells the Edge Node to republish its NBIRTH and DBIRTH(s) messages. This can be
-requested if a Host Application gets an out of order seq number or if a metric arrives in an NDATA
-or DDATA message that was not provided in the original NBIRTH or DBIRTH messages.
+The NCMD payload tells the Edge Node to write true to the 'DIGITAL_OUT_1' metric. As a result, the
+DIGITAL_OUT_1 alue should turn true and result in a NDATA message back to the MQTT Server after the
+DIGITAL_OUT_1 is successfully set to true.
 
 [[payloads_b_dcmd]]
 ==== DCMD

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -289,8 +289,11 @@ message Payload {
         optional string file_type       = 6;        // File type (i.e. xml, json, txt, cpp, etc)
         optional string md5             = 7;        // md5 of data
 
-        // Catchalls and future expansion
+        // Others
         optional string description     = 8;        // Could be anything such as json or xml of custom properties
+        optional string engUnit         = 9;        // Engineering units
+
+        // Future expansion
         extensions                      9 to max;
     }
 

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -331,10 +331,11 @@ message Payload {
     optional uint64   timestamp     = 1;        // Timestamp at message sending time
     repeated Metric   metrics       = 2;        // Repeated forever - no limit in Google Protobufs
     optional uint64   seq           = 3;        // Message sequence number
-    optional string   source        = 4;        // Source for CMD and REBIRTH messages - the Host Application ID that sent the message
-    optional string   uuid          = 5;        // UUID to track message type in terms of schema definitions
-    optional bytes    body          = 6;        // To optionally bypass the whole definition above
-    extensions                      7 to max;   // For third party extensions
+    optional uint64   bd_seq        = 4;        // The Birth/Death sequence number for BIRTH and DEATH payloads
+    optional string   source        = 5;        // Source for CMD and REBIRTH messages - the Host Application ID that sent the message
+    optional string   uuid          = 6;        // UUID to track message type in terms of schema definitions
+    optional bytes    body          = 7;        // To optionally bypass the whole definition above
+    extensions                      8 to max;   // For third party extensions
 }
 ----
 
@@ -434,6 +435,19 @@ NBIRTH message from an Edge Node MUST always contain a sequence number between 0
 **** [tck-testable tck-id-payloads-sequence-num-incrementing]#[yellow-background]*[tck-id-payloads-sequence-num-incrementing] All
 subsequent messages after an NBIRTH from an Edge Node MUST contain a sequence number that is
 continually increasing by one in each message from that Edge Node until a value of
+18446744073709551615 (max value of a UINT64) is reached. At that point, the sequence number of the
+following message MUST be zero.*#
+** _seq_
+*** This is the birth/death sequence number which is an unsigned 64-bit integer.
+**** [tck-testable tck-id-payloads-bd-sequence-num-included]#[yellow-background]*[tck-id-payloads-bd-sequence-num-included] A
+birth/death sequence number MUST be included in the payload of every NBIRTH, NREBIRTH, and NDEATH
+Sparkplug MQTT message from an Edge Node.*#
+**** [tck-testable tck-id-payloads-sequence-num-req-nbirth]#[yellow-background]*[tck-id-payloads-sequence-num-zero-nbirth] Every
+birth/death sequence number included in the payload from an Edge Node MUST always be between 0 and
+18446744073709551615 (inclusive).*#
+**** [tck-testable tck-id-payloads-sequence-num-incrementing]#[yellow-background]*[tck-id-payloads-sequence-num-incrementing] All
+subsequent messages after an NBIRTH from an Edge Node MUST contain a birth/death sequence number
+that is continually increasing by one in each message from that Edge Node until a value of
 18446744073709551615 (max value of a UINT64) is reached. At that point, the sequence number of the
 following message MUST be zero.*#
 ** _source_
@@ -1099,7 +1113,7 @@ Edge Node Descriptor in any Sparkplug infrastructure MUST be unique in the syste
 NBIRTH message MUST include a sequence number and it MUST have a value between 0 and
 18446744073709551615 (inclusive).*#
 * [tck-testable tck-id-payloads-nbirth-bdseq]#[yellow-background]*[tck-id-payloads-nbirth-bdseq] Every
-NBIRTH message MUST include a bdSeq number metric.*#
+NBIRTH message MUST include a bdSeq number in the payload.*#
 * [tck-testable tck-id-payloads-nbirth-bdseq-repeat]#[yellow-background]*[tck-id-payloads-nbirth-bdseq-repeat] The
 bdSeq number value MUST match the bdSeq number value that was sent in the prior MQTT CONNECT packet
 WILL Message.*#
@@ -1136,11 +1150,6 @@ Consider the following Sparkplug B payload in the NBIRTH message shown above:
 {
         "timestamp": 1486144502122,
         "metrics": [{
-                "name": "bdSeq",
-                "timestamp": 1486144502122,
-                "dataType": "Int64",
-                "value": 0
-        }, {
                 "name": "Node Control/Reboot",
                 "timestamp": 1486144502122,
                 "dataType": "Boolean",
@@ -1186,7 +1195,8 @@ Consider the following Sparkplug B payload in the NBIRTH message shown above:
                 "dataType": "Float",
                 "value": 12.1
         }],
-        "seq": 0
+        "seq": 0,
+        "bdSeq": 0
 }
 ----
 
@@ -1222,10 +1232,10 @@ NREBIRTH message MUST include a sequence number that is the following value:*#
 *** pds = Next pending DATA publish seq number
 *** dc = Device count (number of Sparkplug Devices under the scope of the Edge Node)
 * [tck-testable tck-id-payloads-nrebirth-bdseq]#[yellow-background]*[tck-id-payloads-nrebirth-bdseq] Every
-NREBIRTH message MUST include a bdSeq number metric.*#
+NREBIRTH message MUST include a bdSeq number value specified in the payload.*#
 * [tck-testable tck-id-payloads-nrebirth-bdseq-repeat]#[yellow-background]*[tck-id-payloads-nrebirth-bdseq-repeat] The
-bdSeq number value MUST match the bdSeq number value that was sent in the prior MQTT CONNECT packet
-WILL Message.*#
+bdSeq number value MUST match the bdSeq number value that was sent in the immediately prior MQTT
+CONNECT packet WILL Message.*#
 ** Note if a new NREBIRTH is being sent, the Sparkplug Edge Node MQTT client MUST use the same bdSeq
 number in the payload that was sent in the prior MQTT CONNECT packet Will Message payload. This is
 because the NDEATH bdSeq number MUST always match the bdSeq number of the associated NBIRTH that is
@@ -1259,11 +1269,6 @@ Consider the following Sparkplug B payload in the NREBIRTH message shown above:
 {
         "timestamp": 1486144502122,
         "metrics": [{
-                "name": "bdSeq",
-                "timestamp": 1486144502122,
-                "dataType": "Int64",
-                "value": 0
-        }, {
                 "name": "Node Control/Reboot",
                 "timestamp": 1486144502122,
                 "dataType": "Boolean",
@@ -1309,7 +1314,8 @@ Consider the following Sparkplug B payload in the NREBIRTH message shown above:
                 "dataType": "Float",
                 "value": 12.1
         }],
-        "seq": 0
+        "seq": 0,
+        "bdSeq": 0
 }
 ----
 
@@ -1850,7 +1856,8 @@ NDEATH message MUST set the MQTT Will QoS to 1 in the MQTT CONNECT packet.*#
 * [tck-testable tck-id-payloads-ndeath-will-message-retain]#[yellow-background]*[tck-id-payloads-ndeath-will-message-retain] The
 NDEATH message MUST set the MQTT Will Retained flag to false in the MQTT CONNECT packet.*#
 * [tck-testable tck-id-payloads-ndeath-bdseq]#[yellow-background]*[tck-id-payloads-ndeath-bdseq] The
-NDEATH message MUST include the same bdSeq number value that will be used in the associated NBIRTH message.*#
+NDEATH message MUST include the same bdSeq number value that will be used in the associated NBIRTH
+message.*#
 ** This is used by Host Applications to correlate the NDEATH messages with a previously received NBIRTH
 message.
 ** It is important to note that any new CONNECT packet must increment the bdSeq number in the
@@ -1878,7 +1885,8 @@ Server.
 ** It should be noted that this timestamp is typically set at the time of the MQTT CONNECT message
 and as a result may not be useful to Host Applications. If the timestamp is set, Host Applications
 SHOULD NOT use it to determine corresponding NBIRTH messages. Instead, the bdSeq number used in the
-NBIRTH and NDEATH messages MUST be used to determine that an NDEATH matches a prior NBIRTH.
+NBIRTH, NREBIRTH, and NDEATH messages MUST be used to determine that an NDEATH matches a prior
+NBIRTH.
 
 The following is a representation of a NDEATH message on the topic:
 
@@ -1895,17 +1903,12 @@ Consider the following Sparkplug B payload in the NDEATH message shown above:
 ----
 {
         "timestamp": 1486144502122,
-        "metrics": [{
-                "name": "bdSeq",
-                "timestamp": 1486144502122,
-                "dataType": "UInt64",
-                "value": 0
-        }]
+        "bdSeq": 0
 }
 ----
 
-The payload metric named bdSeq allows a Host Application to reconcile this NDEATH with the NBIRTH
-that occurred previously.
+The bdSeq number value in the payload allows a Host Application to reconcile this NDEATH with the
+NBIRTH and/or NREBIRTH that occurred previously.
 
 [[payloads_b_ddeath]]
 ==== DDEATH


### PR DESCRIPTION
[#447] Modified the spec to break out rebirth requests into their own topic verb
[#535] Upticked max values for seq and bdSeq numbers from 255 to 18446744073709551615 (max value of a UINT64)
[#104] Added engUnit property to the MetaData fields
[#124] Modified the spec to allow for omission of Metric level timestamps
[#232] Modified the spec to use nanosecond timestamps instead of millisecond timestamps
[#306] Added 'source' field to the payload for REBIRTH and CMD messages
[#536] Added bd_seq optional field to the payload definition and modified all associated text