### PR TITLE
Update report.py to work with Windows path separator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,14 +41,14 @@ jobs:
         run: ./gradlew build
 
       - name: Upload specification artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sparkplug_spec
           path: specification/build/docs/pdf/sparkplug_spec.pdf
           if-no-files-found: error
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: tck/build/coverage-report/**/*

--- a/tck/report.py
+++ b/tck/report.py
@@ -312,6 +312,7 @@ if __name__ == "__main__":
     for file in files:
         if not file.endswith("TCKTest.java"):
             print("Processing", file)
+            file = file.replace("\\", "/")
             ids = process(file)
             #print(ids)
             if file.find("test/broker") != -1:


### PR DESCRIPTION
Magic strings "test/broker", "test/host", "test/edge", "test/Monitor" assume a path separator of '/'.  For a quick fix, coerce the filename into that format.