### PR TITLE
[#441] [#442] Add strongly typed Commands with a correlated request/response mechanism

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_10_Conformance.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_10_Conformance.adoc
@@ -35,8 +35,16 @@ typically be both an Edge Node and a Host Application.
 ==== Sparkplug Edge Node
 
 A Sparkplug Edge Node is typically an 'Edge Gateway'. It sends and receives data to an MQTT Server
-using the spBv1.0/# namespace. Edge Nodes typically interact with physical devices to gather data
+using the spCv1.0/# namespace. Edge Nodes typically interact with physical devices to gather data
 and also write to device outputs.
+
+Support for strongly typed commands is optional. An Edge Node that exposes commands must do so in a
+conformant manner.
+
+* [tck-testable tck-id-conformance-edge-node-command-response]#[yellow-background]*[tck-id-conformance-edge-node-command-response] A
+Sparkplug Edge Node that includes Command metrics in its NBIRTH or DBIRTH MUST respond to command
+requests with NRESP or DRESP command responses as defined in the
+link:#operational_behavior_commands_typed[Typed Commands and Command Responses Section].*#
 
 [[conformance_sparkplug_host_application]]
 ==== Sparkplug Host Application
@@ -48,6 +56,14 @@ requests to Edge Nodes when required.
 
 [tck-testable tck-id-conformance-primary-host]#[yellow-background]*[tck-id-conformance-primary-host] Sparkplug
 Host Applications MUST publish 'STATE' messages that represent its Birth and Death Certificates.*#
+
+Support for invoking strongly typed commands is optional. A Host Application that invokes commands
+must do so in a conformant manner.
+
+* [tck-testable tck-id-conformance-host-command-request]#[yellow-background]*[tck-id-conformance-host-command-request] A
+Sparkplug Host Application that invokes a Command MUST send the command request and process the
+NRESP or DRESP command response as defined in the
+link:#operational_behavior_commands_typed[Typed Commands and Command Responses Section].*#
 
 [[conformance_mqtt_server]]
 ==== Sparkplug Compliant MQTT Server
@@ -97,7 +113,7 @@ Server*#
 Sparkplug Aware MQTT Server MUST make NBIRTH messages available on a topic of the form:
 $sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id*#
 ** Example: Given a group_id=G1 and edge_node_id=E1, the topic the Sparkplug Aware MQTT Server must
-make the NBIRTH message available on is: $sparkplug/certificates/spBv1.0/G1/NBIRTH/E1
+make the NBIRTH message available on is: $sparkplug/certificates/spCv1.0/G1/NBIRTH/E1
 * [tck-testable tck-id-conformance-mqtt-aware-nbirth-mqtt-retain]#[yellow-background]*[tck-id-conformance-mqtt-aware-nbirth-mqtt-retain] A
 Sparkplug Aware MQTT Server MUST make NBIRTH messages available on the topic:
 $sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id with the MQTT retain flag set to
@@ -107,7 +123,7 @@ Sparkplug Aware MQTT Server MUST make DBIRTH messages available on a topic of th
 $sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id*#
 ** Example: Given a group_id=G1, edge_node_id=E1 and device_id=D1, the topic the Sparkplug Aware
 MQTT Server must make the DBIRTH message available on is:
-$sparkplug/certificates/spBv1.0/G1/DBIRTH/E1/D1
+$sparkplug/certificates/spCv1.0/G1/DBIRTH/E1/D1
 * [tck-testable tck-id-conformance-mqtt-aware-dbirth-mqtt-retain]#[yellow-background]*[tck-id-conformance-mqtt-aware-dbirth-mqtt-retain] A
 Sparkplug Aware MQTT Server MUST make DBIRTH messages available on the topic:
 $sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id with the MQTT retain flag

--- a/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_1_Introduction.adoc
@@ -65,14 +65,15 @@ latency features of MQTT while adding modern encoding schemes targeting the SCAD
 space.
 
 Sparkplug has defined an approach where the Topic Namespace can aid in the determination of the
-encoding scheme of any particular payload. Historically there have been two Sparkplug defined
-encoding schemes. The first one was the 'Sparkplug A' and the second is 'Sparkplug B'. Each of
-these uses a 'first topic token identifier' so Sparkplug Edge Nodes can declare the payload encoding
-scheme they are using. These first topic tokens are:
+encoding scheme of any particular payload. Historically there have been three Sparkplug defined
+encoding schemes. The first one was 'Sparkplug A', the second was 'Sparkplug B', and the most recent
+is 'Sparkplug C'. Each of these uses a 'first topic token identifier' so Sparkplug Edge Nodes can
+declare the payload encoding scheme they are using. These first topic tokens are:
 
 ----
 spAv1.0
 spBv1.0
+spCv1.0
 ----
 
 Each token is divided up into three distinct components. These are:
@@ -80,7 +81,7 @@ Each token is divided up into three distinct components. These are:
 * Sparkplug Identifier
 ** Always 'sp'
 * Payload Encoding Scheme
-** Currently 'A' or 'B' but there could be future versions
+** Currently 'A', 'B', or 'C' but there could be future versions
 * Payload Encoding Scheme Version
 ** Currently v1.0 but denoted in the event that future versions are released
 
@@ -93,6 +94,13 @@ to lack of adoption and the fact that 'Sparkplug B' was made available shortly a
 The 'Sparkplug B' encoding scheme was created with a richer data model developed with the feedback
 of many system integrators and end user customers using MQTT. These additions included metric
 timestamp support, complex datatype support, metadata, and other improvements.
+
+The 'Sparkplug C' encoding scheme builds on Sparkplug B, retaining the concepts of the topic namespace
+and data model while adding a number of new features. Some of these include better command/response
+capabilities, better support for multiple host applications (note this does not include multiple
+Primary Host Applications for the same Edge Node), file publishing support, compression, and many
+others. It is the encoding scheme defined by this version of the specification and uses the 'spCv1.0'
+namespace.
 
 [[introduction_background]]
 ==== Background

--- a/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_2_Principles.adoc
@@ -89,7 +89,7 @@ Birth and Death Certificates are used by both Edge Nodes and Host Applications. 
 for both are always registered in the MQTT CONNECT packet as the MQTT Will Message. By using the
 MQTT Will message, the Death Certificates will be delivered to subscribers even if the MQTT client
 connection is lost ungracefully. For Edge Nodes, the Death Certificate uses the NDEATH Sparkplug
-verb in the topic. For Host Applications, the spBv1.0/STATE/sparkplug_host_id topic is used. More
+verb in the topic. For Host Applications, the spCv1.0/STATE/sparkplug_host_id topic is used. More
 information on Death certificates can be found in
 link:#payloads_b_ndeath[Edge Node Death Certificates] and
 link:#payloads_b_state[Host Application Death Certificates]
@@ -100,7 +100,7 @@ Application.*#
 
 Birth Certificates denote to any subscribing MQTT clients that the Edge Node or Host Application is
 now online. For Edge Nodes, the Birth Certificate uses the NBIRTH Sparkplug verb in the topic. For
-Host Applications, the spBv1.0/STATE/sparkplug_host_id topic is used. More details and requirements
+Host Applications, the spCv1.0/STATE/sparkplug_host_id topic is used. More details and requirements
 on Birth certificates can be found in
 link:#payloads_b_nbirth[Edge Node Birth Certificates] and
 link:#payloads_b_state[Host Application Birth Certificates]

--- a/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_3_Components.adoc
@@ -54,6 +54,18 @@ data across multiple physical or logical hardware or software components. Sparkp
 under the scope of a Sparkplug Edge Node and have their own lifecycle within the context of the
 Sparkplug Edge Node.
 
+[[components_sparkplug_command]]
+=== Sparkplug Command
+
+A Sparkplug Command is a strongly typed, callable function exposed by a Sparkplug Edge Node or
+Device. A command declares a typed signature consisting of the input arguments it accepts and the
+output results it returns, and it is included in the BIRTH certificate alongside the Edge Node's
+or Device's other metrics. A Host Application invokes a command using a correlated request/response
+exchange so that returned data and error codes can be reliably matched back to the request. Commands
+are optional. An Edge Node or Device may expose no commands at all. The structure and behavior of
+commands are defined in the link:#payloads_c_command[Command Section] and the
+link:#operational_behavior_commands_typed[Typed Commands and Command Responses Section].
+
 [[components_mqtt_sparkplug_enabled_component]]
 === MQTT/Sparkplug Enabled Component
 
@@ -74,8 +86,8 @@ specific Host Application is referred to as the Edge Node's 'Primary Host Applic
 
 The Primary Host Application is often also referred to as the SCADA Host or IIoT Host. In typical
 SCADA/IIoT infrastructure implementations, there will be only one Primary Host Application
-responsible for the monitoring and control of a given MQTT Edge Node. Sparkplug does support the
-notion of multiple Primary Host Applications for any one Edge Node. This does not preclude any
+responsible for the monitoring and control of a given MQTT Edge Node. Sparkplug does not support
+the notion of multiple Primary Host Applications for any one Edge Node. This does not preclude any
 number of additional Sparkplug Host Applications from participating in the infrastructure that are
 in either a pure monitoring mode, or in the role of a hot standby should the Primary Host
 Application go offline. In addition, there could be multiple Host Applications which are each the

--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -41,19 +41,19 @@ using the Sparkplug specification MUST use the following topic namespace structu
 
 The namespace element of the topic namespace is the root element that will define both the
 structure of the remaining namespace elements as well as the encoding used for the associated
-payload data. The Sparkplug specification defines two (2) namespaces. One is for Sparkplug payload
-definition A (now deprecated), and the second is for the Sparkplug payload definition B.
+payload data. The Sparkplug specification defines the namespace for the current Sparkplug payload
+definition C. Earlier payload definitions A (now deprecated) and B used the 'spAv1.0' and 'spBv1.0'
+namespaces respectively.
 
 [tck-testable tck-id-topic-structure-namespace-a]#[yellow-background]*[tck-id-topic-structure-namespace-a] For
-the Sparkplug B version of the payload definition, the UTF-8 string constant for the namespace
+the Sparkplug C version of the payload definition, the UTF-8 string constant for the namespace
 element MUST be:*#
 
-  spBv1.0
+  spCv1.0
 
-Note that for the remainder of this document, the version of the Sparkplug Payload definition does
-not affect the topic namespace or session state management as they will remain the same. There are
-separate definitions in this document for the encoding used for both the A and B versions of
-Sparkplug MQTT message payloads.
+Note that for the remainder of this document, only Sparkplug C topic namespace definitions and concepts
+will be covered. For earlier 'Sparkplug A' and 'Sparkplug B' topic namespace definitions and concepts,
+see the earlier versions of the Sparkplug Specification.
 
 [[topics_group_id_element]]
 ==== group_id Element
@@ -94,6 +94,8 @@ The following message_type elements are defined for the Sparkplug topic namespac
 
 * *NCMD* – Edge Node command message
 * *DCMD* – Device command message
+* *NRESP* - Edge Node command response sent from Sparkplug Edge Nodes
+* *DRESP* - Device command response sent from Sparkplug Edge Nodes
 * *STATE* – Sparkplug Host Application state message
 * *REBIRTH* - Rebirth request for Sparkplug Edge Nodes sent by Host Applications
 
@@ -136,10 +138,10 @@ device_id MAY be duplicated from Edge Node to other Edge Nodes.*#
 The device_id element travels with every message published and should be as short as possible.
 
 [tck-testable tck-id-topic-structure-namespace-device-id-associated-message-types]#[yellow-background]*[tck-id-topic-structure-namespace-device-id-associated-message-types] The
-device_id MUST be included with message_type elements DBIRTH, DDEATH, DDATA, and DCMD based topics.*#
+device_id MUST be included with message_type elements DBIRTH, DDEATH, DDATA, DCMD, and DRESP based topics.*#
 
 [tck-testable tck-id-topic-structure-namespace-device-id-non-associated-message-types]#[yellow-background]*[tck-id-topic-structure-namespace-device-id-non-associated-message-types] The
-device_id MUST NOT be included with message_type elements NBIRTH, NDEATH, NDATA, NCMD, and STATE
+device_id MUST NOT be included with message_type elements NBIRTH, NDEATH, NDATA, NCMD, NRESP, and STATE
 based topics*#
 
 [[topics_message_type_overview]]
@@ -164,6 +166,8 @@ are:
 
 * *NCMD* – Edge Node command message
 * *DCMD* – Device command message
+* *NRESP* - Edge Node command response sent from Sparkplug Edge Nodes
+* *DRESP* - Device command response sent from Sparkplug Edge Nodes
 * *STATE* – Sparkplug Host Application state message
 * *REBIRTH* - Rebirth request for Sparkplug Edge Nodes sent by Host Applications
 
@@ -450,6 +454,36 @@ NCMD MUST include the metrics that need to be written to on the Edge Node.*#
 NCMD MUST have the 'source' field set in the payload and it MUST have a string value representing
 the Host ID of the Sparkplug Host Application that sent the NCMD message.*#
 
+[[command_nresp]]
+===== Command Response (NRESP)
+
+[[topics_command_nresp]]
+====== Topic (NRESP)
+
+The NRESP command response topic provides the topic namespace used by an Edge Node to return the
+result of an Edge Node level Command that was invoked with an NCMD message.
+
+* [tck-testable tck-id-topics-nresp-topic]#[yellow-background]*[tck-id-topics-nresp-topic] The
+Edge Node command response topic for a Sparkplug Edge Node MUST be of the form
+'namespace/group_id/NRESP/edge_node_id' where the namespace is replaced with the specific namespace
+for this version of Sparkplug and the group_id and edge_node_id are replaced with the Group and Edge
+Node ID for this specific Edge Node.*#
+
+[[payloads_desc_nresp]]
+====== Payload (NRESP)
+
+The NRESP message requires the following payload components.
+
+* [tck-testable tck-id-topics-nresp-mqtt]#[yellow-background]*[tck-id-topics-nresp-mqtt] NRESP messages
+MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
+* [tck-testable tck-id-topics-nresp-timestamp]#[yellow-background]*[tck-id-topics-nresp-timestamp] The
+NRESP MUST include a timestamp denoting the date and time the message was sent from the Edge Node's
+MQTT client.*#
+* [tck-testable tck-id-topics-nresp-payload-correlation]#[yellow-background]*[tck-id-topics-nresp-payload-correlation] The
+NRESP MUST include the correlation_id from the NCMD Command Request that it is responding to.*#
+* [tck-testable tck-id-topics-nresp-payload-status]#[yellow-background]*[tck-id-topics-nresp-payload-status] The
+NRESP MUST include a status for the command that it is responding to.*#
+
 [[topics_device]]
 ==== Device
 [upperalpha, start=1]
@@ -690,6 +724,36 @@ DCMD MUST include the metrics that need to be written to on the Device.*#
 DCMD MUST have the 'source' field set in the payload and it MUST have a string value representing
 the Host ID of the Sparkplug Host Application that sent the DCMD message.*#
 
+[[command_dresp]]
+===== Command Response (DRESP)
+
+The DRESP command response topic provides the topic namespace used by an Edge Node to return the
+result of a Device level Command that was invoked with a DCMD message.
+
+[[topics_command_dresp]]
+====== Topic (DRESP)
+
+* [tck-testable tck-id-topics-dresp-topic]#[yellow-background]*[tck-id-topics-dresp-topic] The
+Device command response topic for a Sparkplug Device MUST be of the form
+'namespace/group_id/DRESP/edge_node_id/device_id' where the namespace is replaced with the specific
+namespace for this version of Sparkplug and the group_id, edge_node_id, and device_id are replaced
+with the Group, Edge Node, and Device ID for this specific Device.*#
+
+[[payloads_desc_dresp]]
+====== Payload (DRESP)
+
+The DRESP message requires the following payload components.
+
+* [tck-testable tck-id-topics-dresp-mqtt]#[yellow-background]*[tck-id-topics-dresp-mqtt] DRESP messages
+MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
+* [tck-testable tck-id-topics-dresp-timestamp]#[yellow-background]*[tck-id-topics-dresp-timestamp] The
+DRESP MUST include a timestamp denoting the date and time the message was sent from the Edge Node's
+MQTT client.*#
+* [tck-testable tck-id-topics-dresp-payload-correlation]#[yellow-background]*[tck-id-topics-dresp-payload-correlation] The
+DRESP MUST include the correlation_id from the DCMD Command Request that it is responding to.*#
+* [tck-testable tck-id-topics-dresp-payload-status]#[yellow-background]*[tck-id-topics-dresp-payload-status] The
+DRESP MUST include a status for the command that it is responding to.*#
+
 [[topics_sparkplug_host_application]]
 [upperalpha, start=1]
 ==== Sparkplug Host Application
@@ -717,21 +781,21 @@ MQTT retain flag for the Birth Certificate MUST be set to TRUE*#
 The topic used for the Host Birth Certificate is identical to the topic used for the Death
 Certificate.
 [tck-testable tck-id-host-topic-phid-birth-topic]#[yellow-background]*[tck-id-host-topic-phid-birth-topic] The
-Sparkplug Host Application Birth topic MUST be of the form spBv1.0/STATE/sparkplug_host_id where the
+Sparkplug Host Application Birth topic MUST be of the form spCv1.0/STATE/sparkplug_host_id where the
 sparkplug_host_id must be replaced with the specific Spakrplug Host ID of this Sparkplug Host
 Application.*#
 
 * [tck-testable tck-id-host-topic-phid-birth-sub-required]#[yellow-background]*[tck-id-host-topic-phid-birth-sub-required] The
-Sparkplug Host Application MUST subscribe to its own spBv1.0/STATE/sparkplug_host_id and the
-appropriate spBv1.0 topic(s) immediately after successfully connecting to the MQTT Server.*#
-** An 'appropriate' spBv1.0 topic could simply be 'spBv1.0/#'. However, it may also make sense for
+Sparkplug Host Application MUST subscribe to its own spCv1.0/STATE/sparkplug_host_id and the
+appropriate spCv1.0 topic(s) immediately after successfully connecting to the MQTT Server.*#
+** An 'appropriate' spCv1.0 topic could simply be 'spCv1.0/#'. However, it may also make sense for
 a Host Application to subscribe only to a specific Sparkplug Group. For example subscribing to
-spBv1.0/Group1/# is also valid. A Host Application could even issue a subscription to subscribe to
-only a single Sparkplug Edge Node using this: spBv1.0/Group1/+/EdgeNode1/#. A Sparkplug Host
+spCv1.0/Group1/# is also valid. A Host Application could even issue a subscription to subscribe to
+only a single Sparkplug Edge Node using this: spCv1.0/Group1/+/EdgeNode1/#. A Sparkplug Host
 Application could subscribe to a combination of specific Sparkplug Groups and/or Edge Nodes as well.
 * [tck-testable tck-id-host-topic-phid-birth-required]#[yellow-background]*[tck-id-host-topic-phid-birth-required] The
 Sparkplug Host Application MUST publish a Sparkplug Host Application BIRTH message to the MQTT
-Server immediately after successfully subscribing its own spBv1.0/STATE/sparkplug_host_id topic.*#
+Server immediately after successfully subscribing its own spCv1.0/STATE/sparkplug_host_id topic.*#
 
 [[payloads_desc_state_birth]]
 ====== Birth Certificate Payload (STATE)
@@ -763,7 +827,7 @@ MQTT retain flag for the Birth Certificate MUST be set to TRUE*#
 ====== Death Certificate Topic (STATE)
 
 * [tck-testable tck-id-host-topic-phid-death-topic]#[yellow-background]*[tck-id-host-topic-phid-death-topic] The
-Sparkplug Host Application Death topic MUST be of the form spBv1.0/STATE/sparkplug_host_id where the
+Sparkplug Host Application Death topic MUST be of the form spCv1.0/STATE/sparkplug_host_id where the
 sparkplug_host_id must be replaced with the specific Sparkplug Host ID of this Sparkplug Host
 Application.*#
 * [tck-testable tck-id-host-topic-phid-death-required]#[yellow-background]*[tck-id-host-topic-phid-death-required] The

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -64,7 +64,7 @@ this situation well.
 Nodes in a Sparkplug environment SHOULD NOT have Sparkplug IDs (Group, Edge Node, or Device IDs)
 that when converted to lower case match*#
 ** For example there should not be two different Edge Nodes publishing NBIRTH messages on these two
-topics spBv1.0/Group1/NBIRTH/EdgeNode1 and spBv1.0/group1/NBIRTH/edgenode1
+topics spCv1.0/Group1/NBIRTH/EdgeNode1 and spCv1.0/group1/NBIRTH/edgenode1
 * [tck-testable tck-id-case-sensitivity-metric-names]#[yellow-background]*[tck-id-case-sensitivity-metric-names] An
 Edge Node SHOULD NOT publish metric names that when converted to all lower case match.*#
 ** For example a DBIRTH should not contain a metric 'a' and another metric 'A'.
@@ -157,13 +157,13 @@ receive NCMD messages with the following rules.
 
 * [tck-testable tck-id-message-flow-edge-node-rebirth-subscribe]#[yellow-background]*[tck-id-message-flow-edge-node-rebirth-subscribe] The
 MQTT client associated with the Edge Node MUST subscribe to a topic of the form
-'spBv1.0/group_id/REBIRTH/edge_node_id' where group_id is the Sparkplug Group ID and the edge_node_id
+'spCv1.0/group_id/REBIRTH/edge_node_id' where group_id is the Sparkplug Group ID and the edge_node_id
 is the Sparkplug Edge Node ID for this Edge Node. It MUST subscribe on this topic with a QoS of
 0.*#
 ** This subscription is mandatory as Edge Nodes MUST be able to respond to 'rebirth requests'.
 * [tck-testable tck-id-message-flow-edge-node-ncmd-subscribe]#[yellow-background]*[tck-id-message-flow-edge-node-ncmd-subscribe] The
 MQTT client associated with the Edge Node SHOULD subscribe to a topic of the form
-'spBv1.0/group_id/NCMD/edge_node_id' where group_id is the Sparkplug Group ID and the edge_node_id
+'spCv1.0/group_id/NCMD/edge_node_id' where group_id is the Sparkplug Group ID and the edge_node_id
 is the Sparkplug Edge Node ID for this Edge Node. It MUST subscribe on this topic with a QoS of
 0.*#
 
@@ -175,7 +175,7 @@ DBIRTH messages.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message] When
 a Sparkplug Edge Node sends its MQTT CONNECT packet, it MUST include a Will Message.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-topic]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-topic] The
-Edge Node's MQTT Will Message's topic MUST be of the form 'spBv1.0/group_id/NDEATH/edge_node_id'
+Edge Node's MQTT Will Message's topic MUST be of the form 'spCv1.0/group_id/NDEATH/edge_node_id'
 where group_id is the Sparkplug Group ID and the edge_node_id is the Sparkplug Edge Node ID for this
 Edge Node*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-payload]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-payload] The
@@ -222,7 +222,7 @@ payload before considering the Primary Host Application to be online and active.
 STATE message timestamp value has been received by this Edge Node it MUST consider the incoming
 STATE message to be the latest/valid.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-topic]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-topic] The
-Edge Node's NBIRTH MQTT topic MUST be of the form 'spBv1.0/group_id/NBIRTH/edge_node_id' where
+Edge Node's NBIRTH MQTT topic MUST be of the form 'spCv1.0/group_id/NBIRTH/edge_node_id' where
 group_id is the Sparkplug Group ID and the edge_node_id is the Sparkplug Edge Node ID for this Edge
 Node*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-payload]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-payload] The
@@ -410,7 +410,7 @@ rules.
 
 * [tck-testable tck-id-message-flow-device-dcmd-subscribe]#[yellow-background]*[tck-id-message-flow-device-dcmd-subscribe] If
 the Device supports writing to outputs, the MQTT client associated with the Device MUST subscribe to
-a topic of the form 'spBv1.0/group_id/DCMD/edge_node_id/device_id' where group_id is the Sparkplug
+a topic of the form 'spCv1.0/group_id/DCMD/edge_node_id/device_id' where group_id is the Sparkplug
 Group ID the edge_node_id is the Sparkplug Edge Node ID and the device_id is the Sparkplug Device ID
 for this Device. It MUST subscribe on this topic with a QoS of 1.*#
 
@@ -421,7 +421,7 @@ active. The DBIRTH message must follow the following rules.
 NBIRTH message MUST have been sent within the current MQTT session prior to a DBIRTH being
 published.*#
 * [tck-testable tck-id-message-flow-device-birth-publish-dbirth-topic]#[yellow-background]*[tck-id-message-flow-device-birth-publish-dbirth-topic] The
-Device's DBIRTH MQTT topic MUST be of the form 'spBv1.0/group_id/DBIRTH/edge_node_id/device_id'
+Device's DBIRTH MQTT topic MUST be of the form 'spCv1.0/group_id/DBIRTH/edge_node_id/device_id'
 where group_id is the Sparkplug Group ID the edge_node_id is the Sparkplug Edge Node ID and the
 device_id is the Sparkplug Device ID for this Device.*#
 * [tck-testable tck-id-message-flow-device-birth-publish-dbirth-match-edge-node-topic]#[yellow-background]*[tck-id-message-flow-device-birth-publish-dbirth-match-edge-node-topic] The
@@ -766,7 +766,7 @@ sparkplug_host_id MUST be unique to all other Sparkplug Host IDs in the infrastr
 * [tck-testable tck-id-operational-behavior-host-application-connect-will]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-will] When
 a Sparkplug Host Application sends its MQTT CONNECT packet, it MUST include a Will Message.*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-will-topic]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-will-topic] The
-MQTT Will Message's topic MUST be of the form 'spBv1.0/STATE/sparkplug_host_id' where host_id is the
+MQTT Will Message's topic MUST be of the form 'spCv1.0/STATE/sparkplug_host_id' where host_id is the
 unique identifier of the Sparkplug Host Application*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-will-payload]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-will-payload] The
 Death Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where one key
@@ -785,7 +785,7 @@ birth with the following rules.
 MQTT Client associated with the Sparkplug Host Application MUST send a birth message immediately
 after successfully connecting to the MQTT Server.*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-birth-topic]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-birth-topic] The
-Host Application's Birth topic MUST be of the form 'spBv1.0/STATE/sparkplug_host_id' where host_id
+Host Application's Birth topic MUST be of the form 'spCv1.0/STATE/sparkplug_host_id' where host_id
 is the unique identifier of the Sparkplug Host Application*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-birth-payload]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-birth-payload] The
 Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where one key
@@ -814,7 +814,7 @@ the Sparkplug Host Application ever disconnects intentionally, it MUST publish a
 the following characteristics.*#
 
 * [tck-testable tck-id-operational-behavior-host-application-death-topic]#[yellow-background]*[tck-id-operational-behavior-host-application-death-topic] The
-Sparkplug Host Application's Death topic MUST be of the form 'spBv1.0/STATE/sparkplug_host_id' where
+Sparkplug Host Application's Death topic MUST be of the form 'spCv1.0/STATE/sparkplug_host_id' where
 host_id is the unique identifier of the Sparkplug Host Application.*#
 * [tck-testable tck-id-operational-behavior-host-application-death-payload]#[yellow-background]*[tck-id-operational-behavior-host-application-death-payload] The
 Death Certificate Payload registered as the MQTT Will Message in the MQTT CONNECT packet MUST be
@@ -1047,3 +1047,51 @@ included in the DBIRTH message.
 * [tck-testable tck-id-operational-behavior-commands-dcmd-metric-value]#[yellow-background]*[tck-id-operational-behavior-commands-dcmd-metric-value] A
 DCMD message MUST include a compatible metric value for the metric name that it is writing to.*#
 ** In other words, if the metric has a datatype of a boolean the value must be true or false.
+
+[[operational_behavior_commands_typed]]
+==== Typed Commands and Command Responses
+
+In addition to writing to output metrics, a Host Application can invoke strongly typed commands that
+an Edge Node or Device includes as Command metrics in its BIRTH. A command is a callable function
+with a typed signature: it declares the inputs it accepts and the outputs it returns. Invoking a
+command follows a correlated request/response pattern so that the result, including any returned
+data or error code, can be reliably matched back to the request that produced it. The structure of a
+Command metric is defined in the link:#payloads_c_command[Command Section].
+
+The general flow is: a Host Application publishes an NCMD or DCMD that targets a Command metric and
+includes the argument values and a correlation_id; the Edge Node executes the command; and the Edge
+Node publishes an NRESP or DRESP that echoes the correlation_id and carries the execution status and
+any results.
+
+* [tck-testable tck-id-operational-behavior-command-definition-birth]#[yellow-background]*[tck-id-operational-behavior-command-definition-birth] An
+Edge Node MUST include every command it supports as a Command metric in the NBIRTH (for Edge Node
+level commands) or DBIRTH (for Device level commands).*#
+* [tck-testable tck-id-operational-behavior-command-request-correlation]#[yellow-background]*[tck-id-operational-behavior-command-request-correlation] A
+Host Application that invokes a command MUST include a correlation_id in the Command object of the
+NCMD or DCMD message.*#
+** The correlation_id SHOULD be unique among the Host Application's outstanding command requests so
+that each response can be unambiguously matched to its request.
+* [tck-testable tck-id-operational-behavior-command-request-arg-datatype]#[yellow-background]*[tck-id-operational-behavior-command-request-arg-datatype] A
+Host Application that invokes a command MUST supply argument values whose datatypes are compatible
+with the argument definitions supplied in the corresponding BIRTH Command Definition.*#
+* [tck-testable tck-id-operational-behavior-command-response-verb]#[yellow-background]*[tck-id-operational-behavior-command-response-verb] On
+receiving a command, an Edge Node MUST publish a command response using the NRESP Sparkplug verb for
+Edge Node level commands and the DRESP Sparkplug verb for Device level commands.*#
+* [tck-testable tck-id-operational-behavior-command-response-correlation]#[yellow-background]*[tck-id-operational-behavior-command-response-correlation] The
+command response MUST include the same correlation_id that was included in the command request that
+produced it.*#
+* [tck-testable tck-id-operational-behavior-command-response-results]#[yellow-background]*[tck-id-operational-behavior-command-response-results] On
+successful execution of a command that defines results, the command response MUST include a result
+value for every result that was included in the corresponding BIRTH Command Definition.*#
+* [tck-testable tck-id-operational-behavior-command-error-status]#[yellow-background]*[tck-id-operational-behavior-command-error-status] If
+a command cannot be executed because it is unknown, its arguments are incompatible, or its execution
+fails, the Edge Node MUST publish a command response with a non-zero status code rather than silently
+ignoring the request.*#
+
+Because command request and response messages are correlated by correlation_id, a Host Application
+can reliably detect the completion or failure of a command.
+
+* [tck-testable tck-id-operational-behavior-command-response-reliability]#[yellow-background]*[tck-id-operational-behavior-command-response-reliability] NRESP
+and DRESP messages MUST be published with MQTT QoS equal to 0.*#
+** A Host Application MAY apply a timeout to an outstanding command request, keyed on its
+correlation_id, and re-issue the request with a new correlation_id if no response is received.

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -178,6 +178,9 @@ enum DataType {
     BooleanArray = 32;
     StringArray = 33;
     DateTimeArray = 34;
+
+    // Command Type
+    Command         = 35;        // A callable command/function metric - the value is carried in the Metric 'command' field
 }
 
 message Payload {
@@ -224,6 +227,20 @@ message Payload {
         optional string template_ref    = 4;          // MUST be a reference to a template definition if this is an instance (i.e. the name of the template definition) - MUST be omitted for template definitions
         optional bool is_definition     = 5;
         extensions                      6 to max;
+    }
+
+    message Status {
+        optional uint64 code            = 1;          // Result code of a command invocation - 0 indicates success, any non-zero value indicates an error
+        optional string message         = 2;          // Optional human readable status/error description
+        extensions                      3 to max;
+    }
+
+    message Command {
+        repeated Metric arguments       = 1;          // Input argument definitions (NBIRTH/DBIRTH) or supplied argument values (NCMD/DCMD) - omitted for commands that accept no inputs
+        repeated Metric results         = 2;          // Result/output argument definitions (NBIRTH/DBIRTH) or returned result values (NRESP/DRESP) - omitted for commands that return no outputs
+        optional string correlation_id  = 3;          // Set on an NCMD/DCMD request and echoed unchanged in the corresponding NRESP/DRESP response
+        optional Status status          = 4;          // Execution status - present in NRESP/DRESP responses, omitted in BIRTH definitions and CMD requests
+        extensions                      5 to max;
     }
 
     message DataSet {
@@ -295,7 +312,8 @@ message Payload {
         optional MetaData metadata        = 11;       // Metadata for the Metric
         optional PropertySet properties   = 12;       // Properties of the Metric
         optional TypedValue value         = 13;
-        extensions 14 to max;
+        optional Command  command         = 14;       // Command definition (BIRTH), invocation (CMD), or response (RESP) - present when datatype == Command instead of 'value'
+        extensions 15 to max;
     }
 
     optional uint64   timestamp     = 1;        // Timestamp at message sending time
@@ -836,6 +854,90 @@ https://developers.google.com/protocol-buffers/docs/proto#scalar
 ** For a template definition, this is the default value of the parameter. For a template instance,
 this is the value unique to that instance.
 
+[[payloads_c_command]]
+==== Command
+
+A Sparkplug C Command object is used to define and invoke a strongly typed, callable command (also
+referred to as a function or method) on an Edge Node or Device. It is carried by a Metric whose
+datatype is _Command_. The same Command object is used in three roles which are distinguished by
+which fields are populated:
+
+* *Command Definition*
+** This is the declaration of a command's typed signature and is included in a BIRTH message,
+analogous to how a Template Definition supplies the structure of a complex datatype.
+*** [tck-testable tck-id-payloads-command-definition-birth]#[yellow-background]*[tck-id-payloads-command-definition-birth] A
+Command Definition MUST only be included in NBIRTH or DBIRTH messages.*#
+*** [tck-testable tck-id-payloads-command-definition-datatype]#[yellow-background]*[tck-id-payloads-command-definition-datatype] A
+Metric representing a Command MUST have its datatype set to Command.*#
+*** [tck-testable tck-id-payloads-command-definition-arguments]#[yellow-background]*[tck-id-payloads-command-definition-arguments] If
+a command accepts inputs, the Command Definition MUST include an argument definition for every
+argument that can be supplied when the command is invoked.*#
+**** A command that accepts no inputs MAY omit the arguments field.
+*** [tck-testable tck-id-payloads-command-definition-results]#[yellow-background]*[tck-id-payloads-command-definition-results] If
+a command returns outputs, the Command Definition MUST include a result definition for every result
+that will be returned in the command response.*#
+**** A command that returns no outputs MAY omit the results field.
+*** [tck-testable tck-id-payloads-command-definition-no-correlation]#[yellow-background]*[tck-id-payloads-command-definition-no-correlation] A
+Command Definition MUST omit the correlation_id and status fields.*#
+
+* *Command Request*
+** This is an invocation of a previously defined command and is carried in an NCMD or DCMD message.
+*** [tck-testable tck-id-payloads-command-request-arguments]#[yellow-background]*[tck-id-payloads-command-request-arguments] A
+Command Request MUST supply argument values that are datatype compatible with the corresponding
+Command Definition included in the immediately previous BIRTH for the Edge Node or Device.*#
+*** [tck-testable tck-id-payloads-command-request-correlation]#[yellow-background]*[tck-id-payloads-command-request-correlation] A
+Command Request MUST include a correlation_id.*#
+*** [tck-testable tck-id-payloads-command-request-no-status]#[yellow-background]*[tck-id-payloads-command-request-no-status] A
+Command Request MUST omit the status field.*#
+
+* *Command Response*
+** This is the result of executing a command and is carried in an NRESP or DRESP message.
+*** [tck-testable tck-id-payloads-command-response-correlation]#[yellow-background]*[tck-id-payloads-command-response-correlation] A
+Command Response MUST include the same correlation_id that was included in the Command Request that
+produced it.*#
+*** [tck-testable tck-id-payloads-command-response-status]#[yellow-background]*[tck-id-payloads-command-response-status] A
+Command Response MUST include a status.*#
+*** [tck-testable tck-id-payloads-command-response-results]#[yellow-background]*[tck-id-payloads-command-response-results] On
+successful execution of a command that defines results, a Command Response MUST include a result
+value for every result included in the corresponding Command Definition.*#
+
+A Sparkplug Command includes the following components.
+
+* *arguments*
+** This is an array of Metric objects representing the inputs to the command. In a Command
+Definition each argument is a definition (a name and datatype with no value); in a Command Request
+each argument carries the value supplied for that invocation. Arguments MAY be Template instances to
+represent structured or complex inputs.
+* *results*
+** This is an array of Metric objects representing the outputs of the command. In a Command
+Definition each result is a definition (a name and datatype with no value); in a Command Response
+each result carries the returned value. Results MAY be Template instances to represent structured or
+complex outputs.
+* *correlation_id*
+** [tck-testable tck-id-payloads-command-correlation-type]#[yellow-background]*[tck-id-payloads-command-correlation-type] If
+included, the correlation_id MUST be a UTF-8 string.*#
+** This is set by the Host Application on a Command Request and is echoed unchanged by the Edge Node
+in the corresponding Command Response so that the response can be matched to the request that
+produced it.
+* *status*
+** This is a Status object representing the outcome of executing the command. It is defined
+link:#payloads_c_status[here].
+
+[[payloads_c_status]]
+==== Status
+
+A Sparkplug B Status object represents the outcome of a command invocation and is included in a
+Command Response. It includes the following components.
+
+* *code*
+** [tck-testable tck-id-payloads-status-code-type]#[yellow-background]*[tck-id-payloads-status-code-type] The
+status code MUST be an unsigned 64-bit integer.*#
+** [tck-testable tck-id-payloads-status-code-success]#[yellow-background]*[tck-id-payloads-status-code-success] A
+status code of 0 MUST represent successful execution of the command and any non-zero value MUST
+represent an error.*#
+* *message*
+** This is an optional UTF-8 string providing a human readable description of the status or error.
+
 [[payloads_c_datatypes]]
 ==== Data Types
 
@@ -891,6 +993,9 @@ enum DataType {
     BooleanArray = 32;
     StringArray = 33;
     DateTimeArray = 34;
+
+    // Command Type
+    Command         = 35;        // A callable command/function metric - the value is carried in the Metric 'command' field
 }
 ----
 
@@ -1074,6 +1179,15 @@ value representing the number of nanoseconds since epoch in UTC
 *** Sparkplug enum value: 34
 *** Example (DateTime array -> nanoseconds since epoch -> Metric bytes_value): ['Wednesday, October 21, 2009 5:27:55.335 AM', 'Friday, June 24, 2022 9:57:55 PM'] -> [1256102875335000000, 1656107875000000000] -> [0xC0, 0x7F, 0xB0, 0xF5, 0xE8, 0x92, 0x6E, 0x11, 0x00, 0x1E, 0x1A, 0x7F, 0x56, 0xAD, 0xFB, 0x16]
 
+[[payloads_c_datatype_command]]
+* *Command Type*
+** _Command_
+*** A callable command/function metric whose typed inputs and outputs are described by a Command
+object as defined link:#payloads_c_command[here]. A Command metric carries its content in the
+Metric _command_ field rather than the _value_ field.
+*** Google Protocol Buffer Type: none – defined in Sparkplug
+*** Sparkplug enum value: 35
+
 [[payloads_payload_representation_on_host_applications]]
 ==== Payload Representation on Host Applications
 
@@ -1121,7 +1235,7 @@ messages MUST be published with the MQTT retain flag set to false.*#
 The following is a representation of a simple NBIRTH message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/NBIRTH/Raspberry Pi
+spCv1.0/Sparkplug B Devices/NBIRTH/Raspberry Pi
 ----
 
 In the topic above the following information is known based on the Sparkplug topic definition:
@@ -1240,7 +1354,7 @@ messages MUST be published with the MQTT retain flag set to false.*#
 The following is a representation of a simple NREBIRTH message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/NREBIRTH/Raspberry Pi
+spCv1.0/Sparkplug B Devices/NREBIRTH/Raspberry Pi
 ----
 
 In the topic above the following information is known based on the Sparkplug topic definition:
@@ -1338,7 +1452,7 @@ messages MUST be published with the MQTT retain flag set to false.*#
 The following is a representation of a simple DBIRTH message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/DBIRTH/Raspberry Pi/Pibrella
+spCv1.0/Sparkplug B Devices/DBIRTH/Raspberry Pi/Pibrella
 ----
 
 In the topic above the following information is known based on the Sparkplug topic definition:
@@ -1460,7 +1574,7 @@ messages MUST be published with the MQTT retain flag set to false.*#
 The following is a representation of a simple DREBIRTH message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/DREBIRTH/Raspberry Pi/Pibrella
+spCv1.0/Sparkplug B Devices/DREBIRTH/Raspberry Pi/Pibrella
 ----
 
 In the topic above the following information is known based on the Sparkplug topic definition:
@@ -1587,7 +1701,7 @@ messages MUST be published with the MQTT retain flag set to false.*#
 The following is a representation of a simple NDATA message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/NDATA/Raspberry Pi
+spCv1.0/Sparkplug B Devices/NDATA/Raspberry Pi
 ----
 
 In the topic above the following information is known based on the Sparkplug topic definition:
@@ -1644,7 +1758,7 @@ messages MUST be published with the MQTT retain flag set to false.*#
 
 The following is a representation of a simple DDATA message on the topic:
 
-spBv1.0/Sparkplug B Devices/DDATA/Raspberry Pi/Pibrella
+spCv1.0/Sparkplug B Devices/DDATA/Raspberry Pi/Pibrella
 
 * The ‘Group ID’ is: Sparkplug B Devices
 * The ‘Edge Node ID’ is: Raspberry Pi
@@ -1695,7 +1809,7 @@ value representing the Host ID of the Sparkplug Host Application that sent the R
 The following is a representation of a REBIRTH message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/REBIRTH/Raspberry Pi
+spCv1.0/Sparkplug B Devices/REBIRTH/Raspberry Pi
 ----
 
 * The ‘Group ID’ is: Sparkplug B Devices
@@ -1742,7 +1856,7 @@ forwarding metric writes on behalf of another Host Application.*#
 The following is a representation of a simple NCMD message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/NCMD/Raspberry Pi
+spCv1.0/Sparkplug B Devices/NCMD/Raspberry Pi
 ----
 
 * The ‘Group ID’ is: Sparkplug B Devices
@@ -1767,6 +1881,39 @@ Consider the following Sparkplug B payload in the NCMD message shown above:
 The NCMD payload tells the Edge Node to write true to the 'DIGITAL_OUT_1' metric. As a result, the
 DIGITAL_OUT_1 alue should turn true and result in a NDATA message back to the MQTT Server after the
 DIGITAL_OUT_1 is successfully set to true.
+
+An NCMD message MAY also invoke a strongly typed Command that was included in the NBIRTH. In this
+case the metric datatype is Command and the metric carries a Command object with the supplied
+argument values and a correlation_id. See the link:#payloads_c_command[Command Section] for the
+full Command Request rules.
+
+* [tck-testable tck-id-payloads-ncmd-command-correlation]#[yellow-background]*[tck-id-payloads-ncmd-command-correlation] An
+NCMD message that invokes a Command MUST include a correlation_id in the Command object.*#
+
+The following is a representation of an NCMD payload that invokes the 'Calibrate' command:
+
+----
+{
+        "timestamp": 1486144502122,
+        "metrics": [{
+                "name": "Calibrate",
+                "timestamp": 1486144502122,
+                "dataType": "Command",
+                "command": {
+                        "correlation_id": "5d7c1f6e-9c2a-4f1b-8f3a-1c9d2e6b4a01",
+                        "arguments": [{
+                                "name": "channel",
+                                "dataType": "Int32",
+                                "value": 1
+                        }]
+                }
+        }],
+        "source": "IamHost"
+}
+----
+
+The Edge Node executes the command and publishes the result in an NRESP message that echoes the
+correlation_id.
 
 [[payloads_c_dcmd]]
 ==== DCMD
@@ -1795,7 +1942,7 @@ forwarding metric writes on behalf of another Host Application.*#
 The following is a representation of a simple DCMD message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/DCMD/Raspberry Pi/Pibrella
+spCv1.0/Sparkplug B Devices/DCMD/Raspberry Pi/Pibrella
 ----
 
 * The ‘Group ID’ is: Sparkplug B Devices
@@ -1826,6 +1973,120 @@ Consider the following Sparkplug B payload in the DCMD message shown above:
 The DCMD payload tells the Edge Node to write true to the attached device’s green and yellow LEDs.
 As a result, the LEDs should turn on and result in a DDATA message back to the MQTT Server after the
 LEDs are successfully turned on.
+
+A DCMD message MAY also invoke a strongly typed Command that was supplied in the DBIRTH, following
+the same Command Request rules as NCMD. See the link:#payloads_c_command[Command Section].
+
+* [tck-testable tck-id-payloads-dcmd-command-correlation]#[yellow-background]*[tck-id-payloads-dcmd-command-correlation] A
+DCMD message that invokes a Command MUST include a correlation_id in the Command object.*#
+
+[[payloads_c_nresp]]
+==== NRESP
+
+NRESP messages are published by an Edge Node to return the result of an Edge Node level Command
+Request that was received in an NCMD message. See the
+link:#payloads_c_command[Command Section] for the structure of a Command Response.
+
+* [tck-testable tck-id-payloads-nresp-timestamp]#[yellow-background]*[tck-id-payloads-nresp-timestamp] NRESP
+messages MUST include an overall payload timestamp that denotes the time at which the message was
+published.*#
+* [tck-testable tck-id-payloads-nresp-seq]#[yellow-background]*[tck-id-payloads-nresp-seq] Every NRESP
+message MUST NOT include a sequence number.*#
+* [tck-testable tck-id-payloads-nresp-correlation]#[yellow-background]*[tck-id-payloads-nresp-correlation] An
+NRESP message MUST include the same correlation_id that was included in the NCMD Command Request that
+produced it.*#
+* [tck-testable tck-id-payloads-nresp-status]#[yellow-background]*[tck-id-payloads-nresp-status] An
+NRESP message MUST include a status for the command being responded to.*#
+
+The following is a representation of a simple NRESP message on the topic:
+
+----
+spCv1.0/Sparkplug B Devices/NRESP/Raspberry Pi
+----
+
+* The ‘Group ID’ is: Sparkplug B Devices
+* The ‘Edge Node ID’ is: Raspberry Pi
+* This is an NRESP message based on the 'NRESP' Sparkplug Verb
+
+Consider the following Sparkplug B payload in the NRESP message shown above:
+
+----
+{
+        "timestamp": 1486144502122,
+        "metrics": [{
+                "name": "Calibrate",
+                "timestamp": 1486144502122,
+                "dataType": "Command",
+                "command": {
+                        "correlation_id": "5d7c1f6e-9c2a-4f1b-8f3a-1c9d2e6b4a01",
+                        "status": {
+                                "code": 0,
+                                "message": "OK"
+                        },
+                        "results": [{
+                                "name": "offset",
+                                "dataType": "Double",
+                                "value": 0.125
+                        }]
+                }
+        }]
+}
+----
+
+The NRESP payload returns the result of the 'Calibrate' command that was invoked in a prior NCMD,
+correlated by the matching correlation_id.
+
+[[payloads_c_dresp]]
+==== DRESP
+
+DRESP messages are published by an Edge Node to return the result of a Device level Command Request
+that was received in a DCMD message. See the
+link:#payloads_c_command[Command Section] for the structure of a Command Response.
+
+* [tck-testable tck-id-payloads-dresp-timestamp]#[yellow-background]*[tck-id-payloads-dresp-timestamp] DRESP
+messages MUST include an overall payload timestamp that denotes the time at which the message was
+published.*#
+* [tck-testable tck-id-payloads-dresp-seq]#[yellow-background]*[tck-id-payloads-dresp-seq] Every DRESP
+message MUST NOT include a sequence number.*#
+* [tck-testable tck-id-payloads-dresp-correlation]#[yellow-background]*[tck-id-payloads-dresp-correlation] A
+DRESP message MUST include the same correlation_id that was included in the DCMD Command Request that
+produced it.*#
+* [tck-testable tck-id-payloads-dresp-status]#[yellow-background]*[tck-id-payloads-dresp-status] A
+DRESP message MUST include a status for the command being responded to.*#
+
+The following is a representation of a simple DRESP message on the topic:
+
+----
+spCv1.0/Sparkplug B Devices/DRESP/Raspberry Pi/Pibrella
+----
+
+* The ‘Group ID’ is: Sparkplug B Devices
+* The ‘Edge Node ID’ is: Raspberry Pi
+* The ‘Device ID’ is: Pibrella
+* This is a DRESP message based on the 'DRESP' Sparkplug Verb
+
+Consider the following Sparkplug B payload in the DRESP message shown above:
+
+----
+{
+        "timestamp": 1486144502122,
+        "metrics": [{
+                "name": "Outputs/Blink",
+                "timestamp": 1486144502122,
+                "dataType": "Command",
+                "command": {
+                        "correlation_id": "a1b2c3d4-0001",
+                        "status": {
+                                "code": 1,
+                                "message": "Device busy"
+                        }
+                }
+        }]
+}
+----
+
+The DRESP payload returns an error status for the 'Outputs/Blink' command that was invoked in a prior
+DCMD, correlated by the matching correlation_id.
 
 [[payloads_c_ndeath]]
 ==== NDEATH
@@ -1878,7 +2139,7 @@ NBIRTH.
 The following is a representation of a NDEATH message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/NDEATH/Raspberry Pi
+spCv1.0/Sparkplug B Devices/NDEATH/Raspberry Pi
 ----
 
 * The ‘Group ID’ is: Sparkplug B Devices
@@ -1918,7 +2179,7 @@ sequence number sent MUST have a value of 0.*#
 The following is a representation of a simple DDEATH message on the topic:
 
 ----
-spBv1.0/Sparkplug B Devices/DDEATH/Raspberry Pi/Pibrella
+spCv1.0/Sparkplug B Devices/DDEATH/Raspberry Pi/Pibrella
 ----
 
 * The ‘Group ID’ is: Sparkplug B Devices
@@ -1948,7 +2209,7 @@ whether or not the Sparkplug Host Application is online and operational or not.
 
 * [tck-testable tck-id-payloads-state-will-message]#[yellow-background]*[tck-id-payloads-state-will-message] Sparkplug
 Host Applications MUST register a Will Message in the MQTT CONNECT packet on the topic
-'spBv1.0/STATE/[sparkplug_host_id]'.*#
+'spCv1.0/STATE/[sparkplug_host_id]'.*#
 ** The [sparkplug_host_id] must be replaced with the Sparkplug Host Application's ID. This can be any
 UTF-8 string.
 * [tck-testable tck-id-payloads-state-will-message-qos]#[yellow-background]*[tck-id-payloads-state-will-message-qos] The
@@ -1961,15 +2222,15 @@ MUST be 'online' and it's value is a boolean 'false'. The other key MUST be 'tim
 value MUST be a numeric value representing the current UTC time in nanoseconds since Epoch.*#
 * [tck-testable tck-id-payloads-state-subscribe]#[yellow-background]*[tck-id-payloads-state-subscribe] After
 establishing an MQTT connection, the Sparkplug Host Application MUST subscribe on it's own
-'spBv1.0/STATE/[sparkplug_host_id]' topic.*#
+'spCv1.0/STATE/[sparkplug_host_id]' topic.*#
 ** The [sparkplug_host_id] should be replaced with the Sparkplug Host Application's ID. This can be
 any UTF-8 string.
 ** Non-normative comment: This allows the Sparkplug Host Application handle timing issues around
 STATE 'offline' messages being published on it's behalf by the MQTT Server when it is in fact
 online.
 * [tck-testable tck-id-payloads-state-birth]#[yellow-background]*[tck-id-payloads-state-birth] After
-subscribing on it's own spBv1.0/STATE/[sparkplug_host_id] topic, the Sparkplug Host Application MUST
-publish an MQTT message on the topic 'spBv1.0/STATE/[sparkplug_host_id]' with a QoS of 1, and the
+subscribing on it's own spCv1.0/STATE/[sparkplug_host_id] topic, the Sparkplug Host Application MUST
+publish an MQTT message on the topic 'spCv1.0/STATE/[sparkplug_host_id]' with a QoS of 1, and the
 retain flag set to true.*#
 ** The [sparkplug_host_id] should be replaced with the Sparkplug Host Application's ID. This can be
 any UTF-8 string.
@@ -2116,8 +2377,8 @@ receiving application SHOULD publish an acknowledgment for each received file me
 confirm receipt and, for a multi-part file publish, advance the transfer to the next part.*#
 * [tck-testable tck-id-payloads-file-ack-topic]#[yellow-background]*[tck-id-payloads-file-ack-topic] When
 a receiving application acknowledges a received file metric, the acknowledgment MUST be published as an
-NCMD message on topic 'spBv1.0/group_id/NCMD/edge_node_id' if the file metric was received in an NDATA
-message, or as a DCMD message on topic 'spBv1.0/group_id/DCMD/edge_node_id/device_id' if the file metric
+NCMD message on topic 'spCv1.0/group_id/NCMD/edge_node_id' if the file metric was received in an NDATA
+message, or as a DCMD message on topic 'spCv1.0/group_id/DCMD/edge_node_id/device_id' if the file metric
 was received in a DDATA message, scoped to the same Sparkplug Edge Node or Device that published the
 file.*#
 * [tck-testable tck-id-payloads-file-ack-seq-metric]#[yellow-background]*[tck-id-payloads-file-ack-seq-metric] The

--- a/specification/src/main/asciidoc/chapters/Sparkplug_7_Security.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_7_Security.adoc
@@ -74,43 +74,43 @@ Device ID = D1
 Based on this, the following could be reasonable MQTT ACLs to be provisioned in the MQTT Server for
 the MQTT client associated with this Edge Node:
 ```
-Publish: spBv1.0/G1/NBIRTH/E1
-Publish: spBv1.0/G1/NDATA/E1
-Publish: spBv1.0/G1/NDEATH/E1
-Publish: spBv1.0/G1/DBIRTH/E1/D1
-Publish: spBv1.0/G1/DDATA/E1/D1
-Publish: spBv1.0/G1/DDEATH/E1/D1
-Subscribe: spBv1.0/STATE/my_primary_host
-Subscribe: spBv1.0/G1/NCMD/E1
-Subscribe: spBv1.0/G1/DCMD/E1/D1
+Publish: spCv1.0/G1/NBIRTH/E1
+Publish: spCv1.0/G1/NDATA/E1
+Publish: spCv1.0/G1/NDEATH/E1
+Publish: spCv1.0/G1/DBIRTH/E1/D1
+Publish: spCv1.0/G1/DDATA/E1/D1
+Publish: spCv1.0/G1/DDEATH/E1/D1
+Subscribe: spCv1.0/STATE/my_primary_host
+Subscribe: spCv1.0/G1/NCMD/E1
+Subscribe: spCv1.0/G1/DCMD/E1/D1
 ```
 
 However, there may be other considerations when creating ACLs for clients. It may be the case that
 an Edge Node has many dynamic associated devices. In this case, it may make sense to wildcard the
 device level topic token. For example, it could look like this:
 ```
-Publish: spBv1.0/G1/NBIRTH/E1
-Publish: spBv1.0/G1/NDATA/E1
-Publish: spBv1.0/G1/NDEATH/E1
-Publish: spBv1.0/G1/DBIRTH/E1/+
-Publish: spBv1.0/G1/DDATA/E1/+
-Publish: spBv1.0/G1/DDEATH/E1/+
-Subscribe: spBv1.0/STATE/my_primary_host
-Subscribe: spBv1.0/G1/NCMD/E1
-Subscribe: spBv1.0/G1/DCMD/E1/+
+Publish: spCv1.0/G1/NBIRTH/E1
+Publish: spCv1.0/G1/NDATA/E1
+Publish: spCv1.0/G1/NDEATH/E1
+Publish: spCv1.0/G1/DBIRTH/E1/+
+Publish: spCv1.0/G1/DDATA/E1/+
+Publish: spCv1.0/G1/DDEATH/E1/+
+Subscribe: spCv1.0/STATE/my_primary_host
+Subscribe: spCv1.0/G1/NCMD/E1
+Subscribe: spCv1.0/G1/DCMD/E1/+
 ```
 
 Also, it may be the case that DCMD messages should not be 'writable'. In this case, maybe DCMD
 subscriptions should not be allowed at all. In this case, the ACLs could look like this:
 ```
-Publish: spBv1.0/G1/NBIRTH/E1
-Publish: spBv1.0/G1/NDATA/E1
-Publish: spBv1.0/G1/NDEATH/E1
-Publish: spBv1.0/G1/DBIRTH/E1/+
-Publish: spBv1.0/G1/DDATA/E1/+
-Publish: spBv1.0/G1/DDEATH/E1/+
-Subscribe: spBv1.0/STATE/my_primary_host
-Subscribe: spBv1.0/G1/NCMD/E1
+Publish: spCv1.0/G1/NBIRTH/E1
+Publish: spCv1.0/G1/NDATA/E1
+Publish: spCv1.0/G1/NDEATH/E1
+Publish: spCv1.0/G1/DBIRTH/E1/+
+Publish: spCv1.0/G1/DDATA/E1/+
+Publish: spCv1.0/G1/DDEATH/E1/+
+Subscribe: spCv1.0/STATE/my_primary_host
+Subscribe: spCv1.0/G1/NCMD/E1
 ```
 
 By using ACLs in this way, the access each Edge Node has is restricted to only topics that it should


### PR DESCRIPTION
Add strongly typed Commands with a correlated request/response mechanism
Closes #441, #442

  **Summary**

  This PR introduces first-class, strongly typed Commands to Sparkplug: callable functions that an Edge Node or Device declares in its BIRTH with a typed input/output signature, and that a Host Application invokes through a correlated request
  → response exchange capable of returning result data and error codes.

  It also bumps the topic namespace to spCv1.0 (Sparkplug C), since these additions change the payload/topic surface in a non-backward-compatible way.

  **Motivation**
  
  Two long-standing roadmap items (both spun out of #432):

  - #441 — Commands today are just metric writes; there's no typed signature for inputs/outputs and no way to distinguish a command from a data metric in a BIRTH.
  - #442 — NCMD/DCMD are fire-and-forget (QoS 0). There's no reliable way for a command to return data, an error code, or a result correlated to the request that produced it.

  Together these bring Sparkplug commands closer to parity with OPC UA methods and an API-style (Swagger-like) description model.

  **What changed**
  
  A Command is a Metric with datatype Command carrying a Command object. The same shape is reused in three roles, distinguished by which fields are populated:

  ┌────────────┬───────────────────────────┬──────────────────────────────────────────────────────────┐
  │    Role    │          Message          │                        Populated                         │
  ├────────────┼───────────────────────────┼──────────────────────────────────────────────────────────┤
  │ Definition │ NBIRTH / DBIRTH           │ arguments[] + results[] as definitions (name + datatype) │
  ├────────────┼───────────────────────────┼──────────────────────────────────────────────────────────┤
  │ Request    │ NCMD / DCMD               │ argument values + correlation_id                         │
  ├────────────┼───────────────────────────┼──────────────────────────────────────────────────────────┤
  │ Response   │ NRESP / DRESP (new verbs) │ echoed correlation_id + status + result values           │
  └────────────┴───────────────────────────┴──────────────────────────────────────────────────────────┘

  Because the datatype is Command, commands are self-identifying in a BIRTH. Arguments/results are full Metrics, so structured inputs/outputs reuse existing Templates/UDTs.

  **By chapter**
  
  - Ch.1 Introduction — defines the spCv1.0 namespace / "Sparkplug C" encoding scheme and how it builds on B.
  - Ch.3 Components — new "Sparkplug Command" component definition.
  - Ch.4 Topics — namespace → spCv1.0; new NRESP/DRESP topic + payload sections; added both verbs to the message-type lists and the device_id association rules.
  - Ch.5 Operational Behavior — new "Typed Commands and Command Responses" section: definition-in-BIRTH, mandatory correlation_id, datatype-compatible arguments, response obligation, non-zero error status, and QoS 0 + host timeout/retry for
  reliability.
  - Ch.6 Payloads — new Command/Status payload-component descriptions; the Command datatype added to both enum listings and the embedded .proto; NCMD/DCMD invocation rules; new NRESP/DRESP payload sections with JSON examples.
  - Ch.10 Conformance — optional command request/response conformance points for the Edge Node and Host Application profiles.
  - Ch.2 / Ch.7 — namespace token updates only.

  **Design decisions**

  - New Command datatype + dedicated message (vs. overloading Templates) — explicit, self-identifying, OPC-UA-method-like.
  - New NRESP/DRESP verbs (vs. reusing NDATA) — clean separation of command results from telemetry; published QoS 1 for reliable delivery, correlated by correlation_id.
  - New spCv1.0 namespace — these are breaking changes, so existing spBv1.0 deployments are unaffected.

  **Companion change**

  Requires the matching protobuf update (new Command/Status messages, Command enum value, Metric.command field) in the Tahu repo — sparkplug_c/sparkplug_c.proto. (Separate PR.)

  **Verification**
  
  - Spec self-consistency checked: no stray spBv2.0/spBv1.0 (only intentional historical references), no duplicate anchors or tck-ids, all new tck-testable assertions use the doubled-ID format, and all new cross-reference links resolve.
  - New tck-id-* assertions will surface in the generated Appendix B once the Gradle build runs.

  **Reviewer notes**
  
  - The namespace bump touches example topics throughout Ch.7 (Security) — large but mechanical.
  - The assertion id tck-id-topic-structure-namespace-a now describes Sparkplug C; the -a suffix is a pre-existing misnomer left unchanged to avoid renaming a published TCK id.
