### PR TITLE
Separate data & metadata in BIRTH messages, with modified-metadata (CRUD) support (#445, #448)

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_10_Conformance.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_10_Conformance.adoc
@@ -42,9 +42,19 @@ Support for strongly typed commands is optional. An Edge Node that exposes comma
 conformant manner.
 
 * [tck-testable tck-id-conformance-edge-node-command-response]#[yellow-background]*[tck-id-conformance-edge-node-command-response] A
-Sparkplug Edge Node that includes Command metrics in its NBIRTH or DBIRTH MUST respond to command
+Sparkplug Edge Node that includes Command metrics in its NMETA or DMETA MUST respond to command
 requests with NRESP or DRESP command responses as defined in the
 link:#operational_behavior_commands_typed[Typed Commands and Command Responses Section].*#
+* [tck-testable tck-id-conformance-edge-node-nmeta]#[yellow-background]*[tck-id-conformance-edge-node-nmeta] A
+Sparkplug Edge Node MUST publish an NMETA describing its own metric structure and a DMETA describing
+each of its Devices' metric structures, following all NMETA/DMETA topic and payload requirements.*#
+* [tck-testable tck-id-conformance-edge-node-birth-value-only]#[yellow-background]*[tck-id-conformance-edge-node-birth-value-only] A
+Sparkplug Edge Node MUST publish NBIRTH and DBIRTH messages as value-only messages that reference the
+corresponding NMETA/DMETA by definition identifier and identify each metric by its alias or name.*#
+* [tck-testable tck-id-conformance-edge-node-mmeta]#[yellow-background]*[tck-id-conformance-edge-node-mmeta] A
+Sparkplug Edge Node that changes its metric structure after BIRTH MUST express the change as an
+NMMETA/DMMETA with per-metric operations (ADD, UPDATE, DELETE), and MUST also publish an updated full
+NMETA/DMETA with retain true, rather than requiring a full Rebirth.*#
 
 [[conformance_sparkplug_host_application]]
 ==== Sparkplug Host Application
@@ -64,6 +74,19 @@ must do so in a conformant manner.
 Sparkplug Host Application that invokes a Command MUST send the command request and process the
 NRESP or DRESP command response as defined in the
 link:#operational_behavior_commands_typed[Typed Commands and Command Responses Section].*#
+* [tck-testable tck-id-conformance-host-nmeta-resolve]#[yellow-background]*[tck-id-conformance-host-nmeta-resolve] A
+Sparkplug Host Application MUST resolve metrics in an NBIRTH/DBIRTH/NDATA/DDATA - whether identified
+by alias or by name - against the metric definitions in the NMETA/DMETA sharing the same definition
+identifier.*#
+* [tck-testable tck-id-conformance-host-nmeta-missing]#[yellow-background]*[tck-id-conformance-host-nmeta-missing] If
+a Host Application receives a value message whose definition identifier does not match a known
+NMETA/DMETA, it MUST obtain the matching metadata (from the retained NMETA/DMETA message on its
+Sparkplug topic) before treating the metric structure as complete, and MAY issue a REBIRTH request.*#
+* [tck-testable tck-id-conformance-host-mmeta]#[yellow-background]*[tck-id-conformance-host-mmeta] A
+Sparkplug Host Application MUST apply an NMMETA/DMMETA whose previous definition identifier matches
+its current definition identifier for the Edge Node/Device, MUST recompute the definition identifier,
+and on mismatch MUST obtain the full metadata or issue a REBIRTH request. If the previous definition
+identifier does not match, it MUST NOT apply the operations.*#
 
 [[conformance_mqtt_server]]
 ==== Sparkplug Compliant MQTT Server
@@ -87,47 +110,18 @@ Sparkplug conformant MQTT Server MUST support all aspects of the 'retain flag'*#
 ==== Sparkplug Aware MQTT Server
 
 A 'Sparkplug Aware' MQTT Server includes all of the aspects of a Sparkplug Compliant MQTT Server.
-In addition, it also must have the ability to store NBIRTH and DBIRTH messages of Sparkplug Edge
-Nodes that pass through it. Any stored NBIRTH or DBIRTH message must always be the most recent
-NBIRTH or DBIRTH that was published to the MQTT Server. In addition, it must make the stored NBIRTH
-and DBIRTH messages available to MQTT clients via a retained MQTT message on the appropriate
-$sparkplug topic. Note this does not mean that NBIRTH or DBIRTH messages must be published with the
-MQTT retain flag set to true. NBIRTH and DBIRTH messages must be published with the MQTT retain flag
-set to false. The difference with a 'Sparkplug Aware MQTT Server' is that it will treat NBIRTH and
-DBIRTH messages as though their retain flag is set to true even though it is not when published by
-a Sparkplug Edge Node.
 
-It is important to note these stored messages are the original NBIRTH and DBIRTH messages published
-by each Edge Node. As a result, the metric values can not be expected to be the current values. In a
-typical Sparkplug environment the Edge Node likely would have published NDATA and/or DDATA messages
-after the NBIRTH and DBIRTH messages denoting metric values that had changed at the Edge Node and
-its associated Sparkplug Devices. Consumers of the stored NBIRTH and DBIRTH messages should take
-this into consideration when using the information in the stored NBIRTH and DBIRTH payloads.
+In Sparkplug, an Edge Node's and each Device's metric structure (metadata) is carried in NMETA and
+DMETA messages that are published with the MQTT retain flag set to true. The current metadata is
+therefore retained and delivered to subscribing clients by any Sparkplug Compliant MQTT Server
+through the normal MQTT retain mechanism, including while the Edge Node is offline. As a result, a
+Sparkplug Aware MQTT Server is NOT required to store NBIRTH or DBIRTH messages, and is NOT required to
+republish metadata on a $sparkplug topic; metric structure discovery is provided directly by the
+retained NMETA and DMETA messages on their normal Sparkplug topics. NBIRTH and DBIRTH messages
+continue to be published with the MQTT retain flag set to false and are not retained.
 
 * [tck-testable tck-id-conformance-mqtt-aware-basic]#[yellow-background]*[tck-id-conformance-mqtt-aware-basic] A
 Sparkplug Aware MQTT Server MUST support all aspects of a Sparkplug Compliant MQTT Server*#
-* [tck-testable tck-id-conformance-mqtt-aware-store]#[yellow-background]*[tck-id-conformance-mqtt-aware-store] A
-Sparkplug Aware MQTT Server MUST store NBIRTH and DBIRTH messages as they pass through the MQTT
-Server*#
-* [tck-testable tck-id-conformance-mqtt-aware-nbirth-mqtt-topic]#[yellow-background]*[tck-id-conformance-mqtt-aware-nbirth-mqtt-topic] A
-Sparkplug Aware MQTT Server MUST make NBIRTH messages available on a topic of the form:
-$sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id*#
-** Example: Given a group_id=G1 and edge_node_id=E1, the topic the Sparkplug Aware MQTT Server must
-make the NBIRTH message available on is: $sparkplug/certificates/spCv1.0/G1/NBIRTH/E1
-* [tck-testable tck-id-conformance-mqtt-aware-nbirth-mqtt-retain]#[yellow-background]*[tck-id-conformance-mqtt-aware-nbirth-mqtt-retain] A
-Sparkplug Aware MQTT Server MUST make NBIRTH messages available on the topic:
-$sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id with the MQTT retain flag set to
-true*#
-* [tck-testable tck-id-conformance-mqtt-aware-dbirth-mqtt-topic]#[yellow-background]*[tck-id-conformance-mqtt-aware-dbirth-mqtt-topic] A
-Sparkplug Aware MQTT Server MUST make DBIRTH messages available on a topic of the form:
-$sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id*#
-** Example: Given a group_id=G1, edge_node_id=E1 and device_id=D1, the topic the Sparkplug Aware
-MQTT Server must make the DBIRTH message available on is:
-$sparkplug/certificates/spCv1.0/G1/DBIRTH/E1/D1
-* [tck-testable tck-id-conformance-mqtt-aware-dbirth-mqtt-retain]#[yellow-background]*[tck-id-conformance-mqtt-aware-dbirth-mqtt-retain] A
-Sparkplug Aware MQTT Server MUST make DBIRTH messages available on the topic:
-$sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id with the MQTT retain flag
-set to true*#
 * [tck-testable tck-id-conformance-mqtt-aware-ndeath-timestamp]#[yellow-background]*[tck-id-conformance-mqtt-aware-ndeath-timestamp] A
 Sparkplug Aware MQTT Server MAY replace the timestmap of NDEATH messages. If it does, it MUST set
 the timestamp to the UTC time at which it attempts to deliver the NDEATH to subscribed clients*#

--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -81,12 +81,14 @@ version of the Sparkplug implementation as indicated by the namespace element.
 The following message_type elements are defined for the Sparkplug topic namespace:
 
 * *NMETA* - Metadata definition for Sparkplug Edge Nodes
+* *NMMETA* - Modified metadata (metric definition changes) for Sparkplug Edge Nodes
 * *NBIRTH* – Birth certificate for Sparkplug Edge Nodes
 * *NREBIRTH* - Edge Node Rebirth response sent from Sparkplug Edge Nodes
 * *NDATA* – Edge Node data message
 * *NDEATH* – Death certificate for Sparkplug Edge Nodes
 
 * *DMETA* - Metadata definition for Sparkplug Devices
+* *DMMETA* - Modified metadata (metric definition changes) for Sparkplug Devices
 * *DBIRTH* – Birth certificate for Devices
 * *DREBIRTH* - Device Rebirth response sent from Sparkplug Edge Nodes
 * *DDATA* – Device data message
@@ -138,10 +140,10 @@ device_id MAY be duplicated from Edge Node to other Edge Nodes.*#
 The device_id element travels with every message published and should be as short as possible.
 
 [tck-testable tck-id-topic-structure-namespace-device-id-associated-message-types]#[yellow-background]*[tck-id-topic-structure-namespace-device-id-associated-message-types] The
-device_id MUST be included with message_type elements DBIRTH, DDEATH, DDATA, DCMD, and DRESP based topics.*#
+device_id MUST be included with message_type elements DMETA, DMMETA, DBIRTH, DDEATH, DDATA, DCMD, and DRESP based topics.*#
 
 [tck-testable tck-id-topic-structure-namespace-device-id-non-associated-message-types]#[yellow-background]*[tck-id-topic-structure-namespace-device-id-non-associated-message-types] The
-device_id MUST NOT be included with message_type elements NBIRTH, NDEATH, NDATA, NCMD, NRESP, and STATE
+device_id MUST NOT be included with message_type elements NMETA, NMMETA, NBIRTH, NDEATH, NDATA, NCMD, NRESP, and STATE
 based topics*#
 
 [[topics_message_type_overview]]
@@ -153,12 +155,14 @@ real-time SCADA/IIoT, monitoring, and data collection system use cases. The defi
 are:
 
 * *NMETA* - Metadata definition for Sparkplug Edge Nodes
+* *NMMETA* - Modified metadata (metric definition changes) for Sparkplug Edge Nodes
 * *NBIRTH* – Birth certificate for Sparkplug Edge Nodes
 * *NDATA* – Edge Node data message
 * *NDEATH* – Death certificate for Sparkplug Edge Nodes
 * *NREBIRTH* - Edge Node Rebirth response sent from Sparkplug Edge Nodes
 
 * *DMETA* - Metadata definition for Sparkplug Devices
+* *DMMETA* - Modified metadata (metric definition changes) for Sparkplug Devices
 * *DBIRTH* – Birth certificate for Devices
 * *DDATA* – Device data message
 * *DDEATH* – Death certificate for Devices
@@ -185,6 +189,107 @@ This section defines the payload contents and how each of the associated message
 ==== Edge Node
 [upperalpha, start=1]
 
+[[metadata_message_nmeta]]
+===== Metadata Message (NMETA)
+
+The NMETA message describes the metric structure (metadata) of a Sparkplug Edge Node - metric name,
+datatype, alias, properties, metadata, Command-datatype metric definitions, and all Template
+definitions - but not the current metric values. It is identified by a _definition identifier_ that
+is a recalculatable content hash of the metric definitions it contains, and the value-carrying
+NBIRTH, NDATA, DBIRTH and DDATA messages reference that identifier.
+
+An Edge Node makes its complete metric structure available as a full NMETA published with the MQTT
+retain flag set to true, so the MQTT Server retains it and delivers it to any subscriber, including
+while the Edge Node is offline. The Edge Node only needs to publish the full NMETA when the MQTT
+Server does not already have one retained with the current definition identifier (see
+link:#operational_behavior_reconnect_optimization[Reconnect Optimization]). When a full NMETA is
+published as part of a BIRTH sequence, it precedes the NBIRTH that references it. When the metric
+structure changes while the Edge Node is online, the change is published as an NMMETA (see below).
+
+[[topics_metadata_message_nmeta]]
+====== Topic (NMETA)
+
+* [tck-testable tck-id-topics-nmeta-topic]#[yellow-background]*[tck-id-topics-nmeta-topic] The
+Metadata topic for a Sparkplug Edge Node MUST be of the form 'namespace/group_id/NMETA/edge_node_id'
+where the namespace is replaced with the specific namespace for this version of Sparkplug and the
+group_id and edge_node_id are replaced with the Group and Edge Node ID for this specific Edge Node.*#
+
+[[payloads_desc_nmeta]]
+====== Payload (NMETA)
+
+* [tck-testable tck-id-topics-nmeta-mqtt]#[yellow-background]*[tck-id-topics-nmeta-mqtt] A full NMETA
+message MUST be published with MQTT QoS equal to 0 and retain equal to true.*#
+* [tck-testable tck-id-topics-nmeta-timestamp]#[yellow-background]*[tck-id-topics-nmeta-timestamp] The
+NMETA MUST include a timestamp denoting the date and time the metadata was published from the Edge
+Node.*#
+* [tck-testable tck-id-topics-nmeta-defid]#[yellow-background]*[tck-id-topics-nmeta-defid] The NMETA
+MUST include a definition identifier that is the content hash of the Edge Node metric definitions it
+contains.*#
+* [tck-testable tck-id-topics-nmeta-metric-reqs]#[yellow-background]*[tck-id-topics-nmeta-metric-reqs] A
+full NMETA MUST include every metric the Edge Node will report on.*#
+* [tck-testable tck-id-topics-nmeta-cmd-metrics]#[yellow-background]*[tck-id-topics-nmeta-cmd-metrics] A
+full NMETA MUST include the definition of every Command-datatype metric the Edge Node exposes,
+including its command argument and result definitions.*#
+* [tck-testable tck-id-topics-nmeta-metrics]#[yellow-background]*[tck-id-topics-nmeta-metrics] For each
+metric a full NMETA MUST include the metric name and datatype. The metric alias, properties, and
+metadata MAY also be included; aliases are optional.*#
+* [tck-testable tck-id-topics-nmeta-no-value]#[yellow-background]*[tck-id-topics-nmeta-no-value] The
+NMETA MUST NOT be used to convey current metric values.*#
+* [tck-testable tck-id-topics-nmeta-templates]#[yellow-background]*[tck-id-topics-nmeta-templates] If
+Template instances will be published by this Edge Node or any of its Sparkplug Devices, all Template
+definitions MUST be published in the NMETA.*#
+* [tck-testable tck-id-topics-nmeta-seq]#[yellow-background]*[tck-id-topics-nmeta-seq] The NMETA MUST
+include a sequence number. When the NMETA is published at the start of a BIRTH sequence it is the
+first message and its sequence number MUST be 0. When the NMETA is published as an update
+(accompanying an NMMETA), its sequence number MUST be one greater than the sequence number of the
+previous message from this Edge Node, unless that message contained a value of 18446744073709551615 (max value of a UINT64), in which case the
+sequence number MUST be 0.*#
+* [tck-testable tck-id-topics-nmeta-bdseq]#[yellow-background]*[tck-id-topics-nmeta-bdseq] The NMETA
+MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
+
+[[metadata_message_nmmeta]]
+===== Modified Metadata Message (NMMETA)
+
+When the metric structure of an Edge Node changes while it is online - a metric is added, removed, or
+modified - the change is conveyed with an NMMETA message. The NMMETA carries only the affected
+metrics, each tagged with an ADD, UPDATE, or DELETE operation, rather than requiring a full Rebirth.
+The NMMETA is published with the MQTT retain flag set to false; to keep the retained metadata
+complete for late or reconnecting consumers, every NMMETA MUST be accompanied by an updated full
+NMETA published with the retain flag set to true. Publishing the small NMMETA lets already-connected
+consumers apply just the delta, while the retained full NMETA keeps the current structure available
+for discovery.
+
+[[topics_metadata_message_nmmeta]]
+====== Topic (NMMETA)
+
+* [tck-testable tck-id-topics-nmmeta-topic]#[yellow-background]*[tck-id-topics-nmmeta-topic] The
+Modified Metadata topic for a Sparkplug Edge Node MUST be of the form
+'namespace/group_id/NMMETA/edge_node_id' where the namespace, group_id, and edge_node_id are replaced
+as for the other Edge Node topics.*#
+
+[[payloads_desc_nmmeta]]
+====== Payload (NMMETA)
+
+* [tck-testable tck-id-topics-nmmeta-mqtt]#[yellow-background]*[tck-id-topics-nmmeta-mqtt] NMMETA
+messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
+* [tck-testable tck-id-topics-nmmeta-full-nmeta]#[yellow-background]*[tck-id-topics-nmmeta-full-nmeta] Every
+NMMETA MUST be accompanied by an updated full NMETA, published with retain equal to true, that
+reflects the complete metric structure after the change.*#
+* [tck-testable tck-id-topics-nmmeta-timestamp]#[yellow-background]*[tck-id-topics-nmmeta-timestamp] The
+NMMETA MUST include a timestamp denoting the date and time the message was sent from the Edge Node.*#
+* [tck-testable tck-id-topics-nmmeta-defid]#[yellow-background]*[tck-id-topics-nmmeta-defid] The NMMETA
+MUST include the definition identifier in effect immediately before the change (previous_definition_id)
+and the definition identifier in effect after applying the operations (definition_id).*#
+* [tck-testable tck-id-topics-nmmeta-operations]#[yellow-background]*[tck-id-topics-nmmeta-operations] The
+NMMETA MUST include only the metrics affected by the change, and each metric MUST carry an operation
+of ADD, UPDATE, or DELETE.*#
+* [tck-testable tck-id-topics-nmmeta-seq]#[yellow-background]*[tck-id-topics-nmmeta-seq] The NMMETA MUST
+include a sequence number that is one greater than the sequence number of the previous message
+published by this Edge Node, unless that message contained a value of 18446744073709551615 (max value of a UINT64), in which case the sequence
+number MUST be 0.*#
+* [tck-testable tck-id-topics-nmmeta-bdseq]#[yellow-background]*[tck-id-topics-nmmeta-bdseq] The NMMETA
+MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
+
 [[birth_message_nbirth]]
 ===== Birth Message (NBIRTH)
 
@@ -200,44 +305,53 @@ Node ID for this specific Edge Node.*#
 [[payloads_desc_nbirth]]
 ====== Payload (NBIRTH)
 
-The Sparkplug Edge Node Birth Certificate payload contains everything required to build out a data
-structure for all metrics for this Edge Node. At the time any Host Application receives an NBIRTH,
-the 'online' state of this Edge Node should be set to 'true' along with the associated 'online' date
-and time parameter. Note that the Edge Node Birth Certificate ONLY indicates the Edge Node itself
-is online and in an MQTT Session, but any devices that have previously published a DBIRTH will still
-have STALE metric quality until the Host Application receives the new DBIRTH messages associated
-with the new Sparkplug session..
+The Sparkplug Edge Node Birth Certificate payload reports the current _values_ of the Edge Node's
+metrics. The metric structure itself (metadata) is described in the Edge Node's NMETA message; the
+NBIRTH references that structure by its definition identifier and identifies each metric by its alias
+or name. At the time any Host Application receives an NBIRTH, the 'online' state of this Edge Node
+should be set to 'true' along with the associated 'online' date and time parameter. Note that the
+Edge Node Birth Certificate ONLY indicates the Edge Node itself is online and in an MQTT Session, but
+any devices that have previously published a DBIRTH will still have STALE metric quality until the
+Host Application receives the new DBIRTH messages associated with the new Sparkplug session.
 
 The NBIRTH message requires the following payload components.
 
 * [tck-testable tck-id-topics-nbirth-mqtt]#[yellow-background]*[tck-id-topics-nbirth-mqtt] NBIRTH
 messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 * [tck-testable tck-id-topics-nbirth-seq-num]#[yellow-background]*[tck-id-topics-nbirth-seq-num] The
-NBIRTH MUST include a sequence number in the payload and it MUST have a value of 0.*#
+NBIRTH MUST include a sequence number in the payload. If no NMETA is published in the BIRTH sequence,
+the NBIRTH is the first message and its sequence number MUST be 0; if an NMETA is published (sequence
+number 0), the NBIRTH's sequence number MUST be 1.*#
 * [tck-testable tck-id-topics-nbirth-timestamp-1]#[yellow-background]*[tck-id-topics-nbirth-timestamp-1] The
 NBIRTH MUST include the overall payload timestamp denoting the date and time the message was sent
 from the Edge Node.*#
 * [tck-testable tck-id-topics-nbirth-timestamp-2]#[yellow-background]*[tck-id-topics-nbirth-timestamp-2] Each
 individual Metric in the payload MAY include its own timestamp. If it does not, it is assumed the
-'metric value change time' is that over the overall payload timestamp included in the NBIRTH
-paylaod.*#
+'metric value change time' is that of the overall payload timestamp included in the NBIRTH payload.*#
+* [tck-testable tck-id-topics-nbirth-defid]#[yellow-background]*[tck-id-topics-nbirth-defid] The NBIRTH
+MUST include a definition identifier equal to the content hash of the NMETA that describes this Edge
+Node.*#
 * [tck-testable tck-id-topics-nbirth-metric-reqs]#[yellow-background]*[tck-id-topics-nbirth-metric-reqs] The
-NBIRTH MUST include every metric the Edge Node will ever report on.*#
-* [tck-testable tck-id-topics-nbirth-metrics]#[yellow-background]*[tck-id-topics-nbirth-metrics] At
-a minimum each metric MUST include the metric name, datatype, and current value.*#
-* [tck-testable tck-id-topics-nbirth-templates]#[yellow-background]*[tck-id-topics-nbirth-templates] If
-Template instances will be published by this Edge Node or any devices, all Template definitions MUST
-be published in the NBIRTH.*#
+NBIRTH MUST report a value for every metric described in the referenced NMETA, with the exception of
+metrics flagged as transient.*#
+* [tck-testable tck-id-topics-nbirth-metrics]#[yellow-background]*[tck-id-topics-nbirth-metrics] Each
+metric in the NBIRTH MUST include its current value and MUST be identified either by its alias, if an
+alias was assigned to it in the referenced NMETA, or otherwise by its metric name.*#
+* [tck-testable tck-id-topics-nbirth-metrics-defined]#[yellow-background]*[tck-id-topics-nbirth-metrics-defined] Every
+metric reported in an NBIRTH MUST be described by the NMETA referenced by the shared definition
+identifier.*#
+* [tck-testable tck-id-topics-nbirth-no-metadata]#[yellow-background]*[tck-id-topics-nbirth-no-metadata] The
+NBIRTH MUST NOT be used to convey metric datatype, properties, or metadata; these are conveyed only
+in the NMETA and NMMETA.*#
 * [tck-testable tck-id-topics-nbirth-bdseq-included]#[yellow-background]*[tck-id-topics-nbirth-bdseq-included] A
-bdSeq number MUST be included in the payload.*#
+bd_seq number MUST be included in the payload, and it MUST match the bd_seq number included in the
+immediately prior MQTT CONNECT packet's Will Message.*#
 * [tck-testable tck-id-topics-nbirth-bdseq-matching]#[yellow-background]*[tck-id-topics-nbirth-bdseq-matching] This
-MUST match the bdSeq number provided in the immediately prior MQTT CONNECT packet’s Will Message
-payload.*#
-** This allows Host Applications to correlate NBIRTHs to NDEATHs.
+matching bd_seq number allows Host Applications to correlate NBIRTHs to NDEATHs.*#
 * [tck-testable tck-id-topics-nbirth-bdseq-increment]#[yellow-background]*[tck-id-topics-nbirth-bdseq-increment] The
-bdSeq number MUST start at zero and increment by one on every new MQTT CONNECT packet until it
+bd_seq number MUST start at zero and increment by one on every new MQTT CONNECT packet until it
 reaches a maximum of 18446744073709551615 (max value of a UINT64). At this point, the following
-bdSeq number MUST be zero.*#
+bd_seq number MUST be zero.*#
 
 The NBIRTH message can also include additional Node Control payload components. These are used by a
 Sparkplug Host Application to control aspects of the Edge Node. The following are examples of Node
@@ -306,15 +420,15 @@ a minimum each metric MUST include the metric name, datatype, and current value.
 Template instances will be published by this Edge Node or any devices, all Template definitions MUST
 be published in the NREBIRTH.*#
 * [tck-testable tck-id-topics-nrebirth-bdseq-included]#[yellow-background]*[tck-id-topics-nrebirth-bdseq-included] A
-bdSeq number MUST be included in the payload.*#
+bd_seq number MUST be included in the payload.*#
 * [tck-testable tck-id-topics-nrebirth-bdseq-matching]#[yellow-background]*[tck-id-topics-nrebirth-bdseq-matching] This
-MUST match the bdSeq number provided in the immediately prior MQTT CONNECT packet’s Will Message
+MUST match the bd_seq number provided in the immediately prior MQTT CONNECT packet’s Will Message
 payload.*#
 ** This allows Host Applications to correlate NREBIRTHs to NDEATHs.
 * [tck-testable tck-id-topics-nrebirth-bdseq-increment]#[yellow-background]*[tck-id-topics-nrebirth-bdseq-increment] The
-bdSeq number MUST start at zero and increment by one on every new MQTT CONNECT packet until it
+bd_seq number MUST start at zero and increment by one on every new MQTT CONNECT packet until it
 reaches a maximum of 18446744073709551615 (max value of a UINT64). At this point, the following
-bdSeq number MUST be zero.*#
+bd_seq number MUST be zero.*#
 
 The NREBIRTH message can also include additional Node Control payload components. These are used by
 a Sparkplug Host Application to control aspects of the Edge Node. The following are examples of Node
@@ -392,8 +506,8 @@ The Death Certificate topic and payload described here are not “published” a
 client, but provided as parameters within the MQTT CONNECT control packet when this Sparkplug Edge
 Node first establishes the MQTT Client session.
 
-Immediately upon reception of an Edge Node Death Certificate (NDEATH message) with a bdSeq number in
-this payload that matches the preceding bdSeq number in the NBIRTH, any Host Application subscribed
+Immediately upon reception of an Edge Node Death Certificate (NDEATH message) with a bd_seq number in
+this payload that matches the preceding bd_seq number in the NBIRTH, any Host Application subscribed
 to this Edge Node should set the data quality of all metrics to STALE and should note the timestamp
 when the NDEATH message was received.
 
@@ -410,7 +524,7 @@ Node ID for this specific Edge Node.*#
 ====== Payload (NDEATH)
 
 * [tck-testable tck-id-topics-ndeath-payload]#[yellow-background]*[tck-id-topics-ndeath-payload] The
-NDEATH message contains a very simple payload that MUST only include a bdSeq number, so that the
+NDEATH message contains a very simple payload that MUST only include a bd_seq number, so that the
 NDEATH event can be associated with the NBIRTH.*#
 Since this is typically published by the MQTT Server on behalf of the Edge Node, information about
 the current state of the Edge Node and its devices is not and cannot be known. As a result,
@@ -488,6 +602,89 @@ NRESP MUST include a status for the command that it is responding to.*#
 ==== Device
 [upperalpha, start=1]
 
+[[metadata_message_dmeta]]
+===== Metadata Message (DMETA)
+
+The DMETA message describes the metric structure (metadata) of a Sparkplug Device. It is the Device
+equivalent of the NMETA message: it contains the definition of every metric the Device will report
+on, including every Command-datatype metric it exposes, but not the current metric values, and it is
+identified by a definition identifier that is a content hash of those definitions. Like the NMETA, a
+full DMETA is published with the MQTT retain flag set to true.
+
+[[topics_metadata_message_dmeta]]
+====== Topic (DMETA)
+
+* [tck-testable tck-id-topics-dmeta-topic]#[yellow-background]*[tck-id-topics-dmeta-topic] The Metadata
+topic for a Sparkplug Device MUST be of the form 'namespace/group_id/DMETA/edge_node_id/device_id'
+where the namespace, group_id, edge_node_id, and device_id are replaced as for the other Device
+topics.*#
+
+[[payloads_desc_dmeta]]
+====== Payload (DMETA)
+
+* [tck-testable tck-id-topics-dmeta-mqtt]#[yellow-background]*[tck-id-topics-dmeta-mqtt] A full DMETA
+message MUST be published with MQTT QoS equal to 0 and retain equal to true.*#
+* [tck-testable tck-id-topics-dmeta-timestamp]#[yellow-background]*[tck-id-topics-dmeta-timestamp] The
+DMETA MUST include a timestamp denoting the date and time the metadata was published from the Edge
+Node.*#
+* [tck-testable tck-id-topics-dmeta-defid]#[yellow-background]*[tck-id-topics-dmeta-defid] The DMETA
+MUST include a definition identifier that is the content hash of the Device metric definitions it
+contains.*#
+* [tck-testable tck-id-topics-dmeta-cmd-metrics]#[yellow-background]*[tck-id-topics-dmeta-cmd-metrics] A
+full DMETA MUST include the definition of every Command-datatype metric the Device exposes, including
+its command argument and result definitions.*#
+* [tck-testable tck-id-topics-dmeta-metrics]#[yellow-background]*[tck-id-topics-dmeta-metrics] For each
+metric a full DMETA MUST include the metric name and datatype. The metric alias, properties, and
+metadata MAY also be included; aliases are optional.*#
+* [tck-testable tck-id-topics-dmeta-no-value]#[yellow-background]*[tck-id-topics-dmeta-no-value] The
+DMETA MUST NOT be used to convey current metric values.*#
+* [tck-testable tck-id-topics-dmeta-seq]#[yellow-background]*[tck-id-topics-dmeta-seq] The DMETA MUST
+include a sequence number that is one greater than the sequence number of the previous message from
+this Edge Node, unless that message contained a value of 18446744073709551615 (max value of a UINT64), in which case the sequence number MUST
+be 0. A DMETA is never the first message of a BIRTH sequence, as it follows the NMETA and NBIRTH.*#
+* [tck-testable tck-id-topics-dmeta-bdseq]#[yellow-background]*[tck-id-topics-dmeta-bdseq] The DMETA
+MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
+
+[[metadata_message_dmmeta]]
+===== Modified Metadata Message (DMMETA)
+
+The DMMETA is the Device equivalent of the NMMETA message. When a Device's metric structure changes
+while it is online, the DMMETA conveys that change as the added, modified, and removed metrics only -
+each tagged with an ADD, UPDATE, or DELETE operation. The DMMETA is published with the MQTT retain
+flag set to false, and is accompanied by an updated full DMETA published with the retain flag set to
+true.
+
+[[topics_metadata_message_dmmeta]]
+====== Topic (DMMETA)
+
+* [tck-testable tck-id-topics-dmmeta-topic]#[yellow-background]*[tck-id-topics-dmmeta-topic] The
+Modified Metadata topic for a Sparkplug Device MUST be of the form
+'namespace/group_id/DMMETA/edge_node_id/device_id' where the namespace, group_id, edge_node_id, and
+device_id are replaced as for the other Device topics.*#
+
+[[payloads_desc_dmmeta]]
+====== Payload (DMMETA)
+
+* [tck-testable tck-id-topics-dmmeta-mqtt]#[yellow-background]*[tck-id-topics-dmmeta-mqtt] DMMETA
+messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
+* [tck-testable tck-id-topics-dmmeta-full-dmeta]#[yellow-background]*[tck-id-topics-dmmeta-full-dmeta] Every
+DMMETA MUST be accompanied by an updated full DMETA, published with retain equal to true, that
+reflects the complete metric structure after the change.*#
+* [tck-testable tck-id-topics-dmmeta-timestamp]#[yellow-background]*[tck-id-topics-dmmeta-timestamp] The
+DMMETA MUST include a timestamp denoting the date and time the message was sent from the Edge Node.*#
+* [tck-testable tck-id-topics-dmmeta-defid]#[yellow-background]*[tck-id-topics-dmmeta-defid] The DMMETA
+MUST include the definition identifier in effect immediately before the change (previous_definition_id)
+and the definition identifier in effect after applying the operations (definition_id).*#
+* [tck-testable tck-id-topics-dmmeta-operations]#[yellow-background]*[tck-id-topics-dmmeta-operations] The
+DMMETA MUST include only the metrics affected by the change, and each metric MUST carry an operation
+of ADD, UPDATE, or DELETE.*#
+* [tck-testable tck-id-topics-dmmeta-seq]#[yellow-background]*[tck-id-topics-dmmeta-seq] The DMMETA MUST
+include a sequence number that is one greater than the sequence number of the previous message
+published by this Edge Node, unless that message contained a value of 18446744073709551615 (max value of a UINT64), in which case the sequence
+number MUST be 0.*#
+* [tck-testable tck-id-topics-dmmeta-bdseq]#[yellow-background]*[tck-id-topics-dmmeta-bdseq] The DMMETA
+MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
+
 [[birth_message_dbirth]]
 ===== Birth Message (DBIRTH)
 
@@ -498,9 +695,11 @@ connected to this node will still need to provide this DBIRTH before Host Applic
 create/update the metric structure (if this is the first time this device has been seen) and set any
 associated metrics in the application to a “*GOOD*” state.
 
-The DBIRTH payload contains everything required to build out a data structure for all metrics for
-this device. The 'online' state of this device should be set to TRUE along with the associated
-'online' date and time this message was received.
+The DBIRTH payload reports the current _values_ of the Device's metrics. The metric structure itself
+(metadata) is described in the Device's DMETA message; the DBIRTH references that structure by its
+definition identifier and identifies each metric by its alias or name. The 'online' state of this
+device should be set to TRUE along with the associated 'online' date and time this message was
+received.
 
 [[topics_birth_message_dbirth]]
 ====== Topic (DBIRTH)
@@ -529,10 +728,21 @@ from the Edge Node.*#
 individual Metric in the payload MAY include its own timestamp. If it does not, it is assumed the
 'metric value change time' is that over the overall payload timestamp included in the DBIRTH
 payload.*#
+* [tck-testable tck-id-topics-dbirth-defid]#[yellow-background]*[tck-id-topics-dbirth-defid] The DBIRTH
+MUST include a definition identifier equal to the content hash of the DMETA that describes this
+Device.*#
 * [tck-testable tck-id-topics-dbirth-metric-reqs]#[yellow-background]*[tck-id-topics-dbirth-metric-reqs] The
-DBIRTH MUST include every metric the Edge Node will ever report on.*#
-* [tck-testable tck-id-topics-dbirth-metrics]#[yellow-background]*[tck-id-topics-dbirth-metrics] At
-a minimum each metric MUST include the metric name, metric datatype, and current value.*#
+DBIRTH MUST report a value for every metric described in the referenced DMETA, with the exception of
+metrics flagged as transient.*#
+* [tck-testable tck-id-topics-dbirth-metrics]#[yellow-background]*[tck-id-topics-dbirth-metrics] Each
+metric in the DBIRTH MUST include its current value and MUST be identified either by its alias, if an
+alias was assigned to it in the referenced DMETA, or otherwise by its metric name.*#
+* [tck-testable tck-id-topics-dbirth-metrics-defined]#[yellow-background]*[tck-id-topics-dbirth-metrics-defined] Every
+metric reported in a DBIRTH MUST be described by the DMETA referenced by the shared definition
+identifier.*#
+* [tck-testable tck-id-topics-dbirth-no-metadata]#[yellow-background]*[tck-id-topics-dbirth-no-metadata] The
+DBIRTH MUST NOT be used to convey metric datatype, properties, or metadata; these are conveyed only
+in the DMETA and DMMETA.*#
 
 The DBIRTH message can also include optional ‘Device Control’ payload components. These are used by
 a Host Application to control aspects of a device. The following are examples of Device Control

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -181,10 +181,10 @@ Edge Node*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-payload]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-payload] The
 Edge Node's MQTT Will Message's payload MUST be a Sparkplug Google Protobuf encoded payload.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-payload-bdSeq]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-payload-bdSeq] The
-Edge Node's MQTT Will Message's payload MUST include a bdSeq number in the payload and the value
+Edge Node's MQTT Will Message's payload MUST include a bd_seq number in the payload and the value
 MUST be incremented by one from the value in the previous MQTT CONNECT packet unless the value would
 be greater than 18446744073709551615 (max value of a UINT64). If in the previous NBIRTH a value of
-18446744073709551615 was sent, the next MQTT Connect packet Will Message payload bdSeq number value
+18446744073709551615 was sent, the next MQTT Connect packet Will Message payload bd_seq number value
 MUST have a value of 0.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-will-message-qos]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-will-message-qos] The
 Edge Node's MQTT Will Message's MQTT QoS MUST be 1.*#
@@ -228,8 +228,8 @@ Node*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-payload]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-payload] The
 Edge Node's NBIRTH payload MUST be a Sparkplug Google Protobuf encoded payload.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-payload-bdSeq]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-payload-bdSeq] The
-Edge Node's NBIRTH payload MUST include a bdSeq number in the payload and the value MUST be the same
-as the bdSeq number value specified in the immediately previous MQTT CONNECT packet.*#
+Edge Node's NBIRTH payload MUST include a bd_seq number in the payload and the value MUST be the same
+as the bd_seq number value specified in the immediately previous MQTT CONNECT packet.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-qos]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-qos] The
 Edge Node's NBIRTH MQTT QoS MUST be 0.*#
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-retained]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-retained] The
@@ -287,19 +287,100 @@ show the Edge Node in an 'online' state once it publishes its NBIRTH and DBIRTH 
 
 . If at any point in time the Edge Node MQTT Client loses connectivity to the defined MQTT
 Server(s), a Death Certificate (NDEATH) is issued by the MQTT Server on behalf of the Edge Node.
-Upon receipt of the Death Certificate with a bdSeq number that matches the preceding bdSeq number in
+Upon receipt of the Death Certificate with a bd_seq number that matches the preceding bd_seq number in
 the NBIRTH messages, the Primary Host Application should set the state of the Edge Node to
 ‘online=false’ and update all metric timestamps related to this Edge Node to 'now' using its own
 system clock. Any defined metrics will be set to a STALE data quality.
 
-.. The bdSeq number is used to correlate an NBIRTH with a NDEATH. Because the NDEATH is included in
+.. The bd_seq number is used to correlate an NBIRTH with a NDEATH. Because the NDEATH is included in
 the MQTT CONNECT packet, its timestamp (if included) is not useful to Sparkplug Host Applications.
-Instead, a bdSeq number must be included in the payload of the NDEATH. The same bdSeq number value
+Instead, a bd_seq number must be included in the payload of the NDEATH. The same bd_seq number value
 must also be included in the NBIRTH message payload published immediately after the MQTT CONNECT.
 This allows Host Applications to know that a NDEATH matches a specific NBIRTH message. This is
 required because timing with Will Messages may result in NDEATH messages arriving after a new/next
-NBIRTH message. The bdSeq number allows Host Applications to know when it must consider the Edge
+NBIRTH message. The bd_seq number allows Host Applications to know when it must consider the Edge
 Node offline.
+
+[[operational_behavior_metadata]]
+=== Metadata Publishing and Updates
+
+An Edge Node's and each Device's metric structure (metadata) is carried in NMETA and DMETA messages,
+separately from the value-carrying NBIRTH, DBIRTH, NDATA, and DDATA messages. This lets the structure
+be established once and reused across reconnects, and lets it be changed after BIRTH without a full
+Rebirth.
+
+[[operational_behavior_metadata_availability]]
+==== Metadata Availability and Ordering
+
+Before publishing its NBIRTH, the Edge Node must ensure that the NMETA the NBIRTH will reference is
+available to consumers. The metadata is considered _available_ if it is published in the current MQTT
+session, or was published (with the MQTT retain flag set to true) in a prior session and therefore
+remains retained by the MQTT Server on the NMETA topic. Because NMETA/DMETA and the BIRTH messages
+are published on different MQTT topics, MQTT does not guarantee their relative arrival order;
+correlation of values to definitions relies on the definition identifier, not on arrival order.
+
+* [tck-testable tck-id-message-flow-birth-metadata-available]#[yellow-background]*[tck-id-message-flow-birth-metadata-available] An
+Edge Node MUST NOT publish an NBIRTH or DBIRTH that references a definition identifier unless the
+corresponding NMETA or DMETA has been made available - either published in the current MQTT session,
+or previously published with retain true and therefore still retained by the MQTT Server on the
+NMETA/DMETA topic.*#
+* [tck-testable tck-id-message-flow-birth-metadata-publish-order]#[yellow-background]*[tck-id-message-flow-birth-metadata-publish-order] When
+an Edge Node publishes an NMETA or DMETA in the same MQTT session as the immediately following NBIRTH
+or DBIRTH that will reference it, it MUST publish the NMETA or DMETA before that BIRTH.*#
+* [tck-testable tck-id-message-flow-host-birth-metadata-resolve]#[yellow-background]*[tck-id-message-flow-host-birth-metadata-resolve] A
+Sparkplug Host Application MUST NOT rely on receiving an NMETA or DMETA before the NBIRTH or DBIRTH
+that references it. If a Host Application receives a BIRTH whose definition identifier does not match
+metadata it already holds, it MUST obtain the referenced metadata - for example by subscribing to the
+retained NMETA/DMETA topic - before interpreting the BIRTH's metric values.*#
+
+[[operational_behavior_reconnect_optimization]]
+==== Reconnect Optimization
+
+Because a full NMETA and DMETA are published with the MQTT retain flag set to true, the MQTT Server
+retains the current metadata on the NMETA/DMETA topic and delivers it to any client that subscribes,
+including while the Edge Node is offline. As a result, an Edge Node whose metric structure is
+unchanged does not need to re-transmit its full metadata on reconnect.
+
+* [tck-testable tck-id-operational-behavior-meta-subscribe]#[yellow-background]*[tck-id-operational-behavior-meta-subscribe] As
+part of its BIRTH sequence, an Edge Node MUST subscribe to its own NMETA topic, and to the DMETA
+topic of each of its Devices, to determine whether the MQTT Server already has a retained NMETA or
+DMETA carrying the current definition identifier.*#
+* [tck-testable tck-id-operational-behavior-meta-conditional-publish]#[yellow-background]*[tck-id-operational-behavior-meta-conditional-publish] An
+Edge Node MUST publish a full NMETA (respectively, a full DMETA) as part of its BIRTH sequence if and
+only if the MQTT Server does not already have a retained NMETA (respectively, DMETA) carrying the
+current definition identifier. In all cases the NBIRTH/DBIRTH MUST reference the current definition
+identifier.*#
+
+[[operational_behavior_modified_metadata_updates]]
+==== Modified Metadata Updates (CRUD)
+
+When the metric structure of an Edge Node or Device changes while it is online - a metric is added,
+removed, or modified - the change is conveyed with an NMMETA or DMMETA message that carries only the
+affected metrics, each tagged with an operation (ADD, UPDATE, or DELETE), rather than requiring a full
+Rebirth.
+
+* [tck-testable tck-id-operational-behavior-mmeta-prev]#[yellow-background]*[tck-id-operational-behavior-mmeta-prev] An
+NMMETA/DMMETA MUST include the definition identifier in effect immediately before the change and the
+definition identifier in effect after applying the operations.*#
+* [tck-testable tck-id-operational-behavior-mmeta-retain-refresh]#[yellow-background]*[tck-id-operational-behavior-mmeta-retain-refresh] An
+NMMETA/DMMETA MUST be published with retain false, and MUST be accompanied by a full NMETA/DMETA
+published with retain true so that the retained metadata on the MQTT Server always reflects the
+complete current metric structure.*#
+* [tck-testable tck-id-operational-behavior-mmeta-value]#[yellow-background]*[tck-id-operational-behavior-mmeta-value] When
+a metric is added by an NMMETA/DMMETA, the Edge Node MUST publish the new metric's initial value in a
+subsequent NDATA/DDATA that references the new definition identifier.*#
+* [tck-testable tck-id-operational-behavior-mmeta-alias-reuse]#[yellow-background]*[tck-id-operational-behavior-mmeta-alias-reuse] An
+alias belonging to a metric removed by a DELETE operation MUST NOT be reused for a different metric
+within the same Edge Node or Device.*#
+* [tck-testable tck-id-operational-behavior-host-mmeta-apply]#[yellow-background]*[tck-id-operational-behavior-host-mmeta-apply] If
+the previous definition identifier of an NMMETA/DMMETA matches the definition identifier the Host
+Application currently holds for that Edge Node/Device, the Host Application MUST apply the operations,
+recompute the definition identifier, and on mismatch with the message's new definition identifier
+issue a REBIRTH request.*#
+* [tck-testable tck-id-operational-behavior-host-mmeta-gap]#[yellow-background]*[tck-id-operational-behavior-host-mmeta-gap] If
+the previous definition identifier of an NMMETA/DMMETA does not match the definition identifier the
+Host Application currently holds, the Host Application MUST NOT apply the operations and MUST obtain
+the current full metadata (from the retained NMETA/DMETA topic) or issue a REBIRTH request.*#
 
 [[operational_behavior_edge_node_session_termination]]
 === Edge Node Session Termination
@@ -321,9 +402,9 @@ some time to occur based on when the MQTT Server detects that the Edge Node is n
 By sending the Death Certificate before disconnecting without sending an MQTT DISCONNECT packet, we
 are ensuring that a Death message will be delivered to subscribing clients promptly. The fact that a
 second Death message will arrive when the Will Message is delivered is not significant. This is
-because the Will Message Death message will contain a bdSeq number that matches the bdSeq number
+because the Will Message Death message will contain a bd_seq number that matches the bd_seq number
 that is published by the Edge Node immediately before the disconnect. Because it has a duplicate
-bdSeq, the Will Message Death message MUST be ignored by the subscribing Sparkplug Host Application
+bd_seq, the Will Message Death message MUST be ignored by the subscribing Sparkplug Host Application
 clients.
 
 This allows the MQTT Server to be notified that the Edge Node is offline and as a result the MQTT
@@ -991,9 +1072,9 @@ an Edge Node receives a Rebirth Request, it MUST immediately pause sending of DA
 an Edge Node stops sending DATA messages, it MUST send a complete REBIRTH sequence including the
 NREBIRTH and DREBIRTH(s) if applicable.*#
 * [tck-testable tck-id-operational-behavior-rebirth-action-3]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-3] The
-NREBIRTH MUST include the same bdSeq number in the payload with the same value it had included in
+NREBIRTH MUST include the same bd_seq number in the payload with the same value it had included in
 the Will Message of the immediately previous MQTT CONNECT packet.*#
-** Because a new MQTT Session is not being established, there is no reason to update the bdSeq number
+** Because a new MQTT Session is not being established, there is no reason to update the bd_seq number
 * [tck-testable tck-id-operational-behavior-rebirth-action-4]#[yellow-background]*[tck-id-operational-behavior-rebirth-action-4] The
 NREBIRTH payload MUST use a seq number that specified to integrate into the existing DATA stream
 from the Edge Node.*#

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -183,6 +183,14 @@ enum DataType {
     Command         = 35;        // A callable command/function metric - the value is carried in the Metric 'command' field
 }
 
+// Per-metric operation, used only within NMMETA/DMMETA (modified metadata) messages to denote a
+// create/update/delete of a metric definition. Absent in NMETA/DMETA/NBIRTH/DBIRTH messages.
+enum MetricOperation {
+    ADD    = 1;
+    UPDATE = 2;
+    DELETE = 3;
+}
+
 message Payload {
 
     message TypedValue {
@@ -313,7 +321,8 @@ message Payload {
         optional PropertySet properties   = 12;       // Properties of the Metric
         optional TypedValue value         = 13;
         optional Command  command         = 14;       // Command definition (BIRTH), invocation (CMD), or response (RESP) - present when datatype == Command instead of 'value'
-        extensions 15 to max;
+        optional MetricOperation operation = 15;      // Only in NMMETA/DMMETA: ADD, UPDATE, or DELETE
+        extensions 16 to max;
     }
 
     optional uint64   timestamp     = 1;        // Timestamp at message sending time
@@ -323,7 +332,9 @@ message Payload {
     optional string   source        = 5;        // Source for CMD and REBIRTH messages - the Host Application ID that sent the message
     optional string   uuid          = 6;        // UUID to track message type in terms of schema definitions
     optional bytes    body          = 7;        // To optionally bypass the whole definition above
-    extensions                      8 to max;   // For third party extensions
+    optional string   definition_id          = 8; // Definition identifier: content hash of the metric definitions this message reports against
+    optional string   previous_definition_id = 9; // NMMETA/DMMETA only: the definition_id in effect before the change
+    extensions                      10 to max;  // For third party extensions
 }
 ----
 
@@ -1194,6 +1205,136 @@ Metric _command_ field rather than the _value_ field.
 Sparkplug B payloads in conjunction with the Sparkplug topic namespace result in hierarchical data 
 structures that can be represented in folder structures with metrics which are often called tags.
 
+[[payloads_c_definition_identifier]]
+==== Definition Identifier
+
+The _definition identifier_ is a recalculatable content hash of the metric definitions (metadata) of
+an Edge Node or Device. It is carried in the payload _definition_id_ field. It correlates a metadata
+message (NMETA/DMETA) with the value messages (NBIRTH/DBIRTH/NDATA/DDATA) that report against it, and
+it allows a consumer to independently verify that it holds the correct metric structure.
+
+The definition identifier MUST be computed as follows so that any implementation computes the same
+value from the same metric definitions:
+
+[arabic]
+. *Metadata projection.* Build a structure containing only definition fields: for every metric its
+name, alias, datatype, the is_transient flag, all properties, metadata, and - for Command-datatype
+metrics - the command argument and result definitions; plus every Template (UDT) definition. Current
+values, quality, quality_context, timestamps, sequence numbers, bd_seq, source, definition_id, and
+previous_definition_id MUST be excluded.
+. *Stable ordering.* The metrics MUST be ordered by metric name, each property set by key, Template
+members by name, and command argument and result definitions by name.
+. *String normalization.* All strings MUST be normalized to Unicode Normalization Form C (NFC).
+. *Canonicalization.* The projection MUST be serialized to a canonical JSON document as defined by
+RFC 8785 (JSON Canonicalization Scheme).
+. *Hash.* The definition identifier MUST be the SHA-256 hash of the UTF-8 bytes of the canonical JSON
+document, rendered as a lowercase hexadecimal string.
+
+* [tck-testable tck-id-payloads-defid-hash]#[yellow-background]*[tck-id-payloads-defid-hash] The
+definition identifier MUST be the lowercase-hex SHA-256 of the RFC 8785 canonicalization of the
+metadata projection defined in this section, and MUST exclude values, quality, timestamps, sequence
+numbers, bd_seq, source, definition_id, and previous_definition_id.*#
+* [tck-testable tck-id-payloads-defid-hash-order]#[yellow-background]*[tck-id-payloads-defid-hash-order] Before
+canonicalization the metrics MUST be ordered by metric name, each property set by key, Template
+members by name, and command arguments and results by name, and all strings MUST be normalized to
+Unicode NFC.*#
+* [tck-testable tck-id-payloads-defid-hash-changes]#[yellow-background]*[tck-id-payloads-defid-hash-changes] Any
+change to a metric name, alias, datatype, properties, metadata, command argument or result
+definition, or to any Template definition MUST result in a different definition identifier.*#
+* [tck-testable tck-id-payloads-defid-hash-recompute]#[yellow-background]*[tck-id-payloads-defid-hash-recompute] A
+consumer MUST be able to recompute the definition identifier from the assembled metadata and obtain a
+value identical to the one published by the Edge Node.*#
+
+[[payloads_c_nmeta]]
+==== NMETA
+
+The NMETA describes the metric structure (metadata) of an Edge Node. It carries the definition of
+every metric the Edge Node will report on, but not the current values. It is identified by a
+definition identifier (the content hash of the definitions it contains). The value-carrying NBIRTH,
+NDATA and (for the Edge Node's Sparkplug Devices) DBIRTH and DDATA messages reference this definition
+identifier. Because the NMETA is published with the MQTT retain flag set to true, the MQTT Server
+retains it and delivers the current structure to any client that subscribes, including while the Edge
+Node is offline.
+
+* [tck-testable tck-id-payloads-nmeta-timestamp]#[yellow-background]*[tck-id-payloads-nmeta-timestamp] NMETA
+messages MUST include a payload timestamp that denotes the time at which the message was published.*#
+* [tck-testable tck-id-payloads-nmeta-defid]#[yellow-background]*[tck-id-payloads-nmeta-defid] NMETA
+messages MUST include a definition_id equal to the content hash of the metric definitions they
+contain.*#
+* [tck-testable tck-id-payloads-nmeta-metric-defs]#[yellow-background]*[tck-id-payloads-nmeta-metric-defs] For
+each metric a full NMETA MUST include the metric name and datatype. The metric alias, properties, and
+metadata MAY also be included; aliases are optional.*#
+* [tck-testable tck-id-payloads-nmeta-cmd-metrics]#[yellow-background]*[tck-id-payloads-nmeta-cmd-metrics] A
+full NMETA MUST include the definition of every Command-datatype metric the Edge Node exposes,
+including its command argument and result definitions, so that Host Applications can invoke it via
+NCMD and process the NRESP response.*#
+* [tck-testable tck-id-payloads-nmeta-no-value]#[yellow-background]*[tck-id-payloads-nmeta-no-value] NMETA
+messages MUST NOT be used to convey current metric values.*#
+* [tck-testable tck-id-payloads-nmeta-qos]#[yellow-background]*[tck-id-payloads-nmeta-qos] NMETA
+messages MUST be published with the MQTT QoS set to 0.*#
+* [tck-testable tck-id-payloads-nmeta-retain]#[yellow-background]*[tck-id-payloads-nmeta-retain] A full
+NMETA MUST be published with the MQTT retain flag set to true, so that the current metric structure
+is retained by the MQTT Server and delivered to any client that subscribes.*#
+
+[[payloads_c_dmeta]]
+==== DMETA
+
+The DMETA describes the metric structure (metadata) of a Sparkplug Device. It is the Device
+equivalent of the NMETA message and follows the same rules, including publication with the MQTT
+retain flag set to true.
+
+* [tck-testable tck-id-payloads-dmeta-timestamp]#[yellow-background]*[tck-id-payloads-dmeta-timestamp] DMETA
+messages MUST include a payload timestamp that denotes the time at which the message was published.*#
+* [tck-testable tck-id-payloads-dmeta-defid]#[yellow-background]*[tck-id-payloads-dmeta-defid] DMETA
+messages MUST include a definition_id equal to the content hash of the metric definitions they
+contain.*#
+* [tck-testable tck-id-payloads-dmeta-metric-defs]#[yellow-background]*[tck-id-payloads-dmeta-metric-defs] For
+each metric a full DMETA MUST include the metric name and datatype. The metric alias, properties, and
+metadata MAY also be included; aliases are optional.*#
+* [tck-testable tck-id-payloads-dmeta-cmd-metrics]#[yellow-background]*[tck-id-payloads-dmeta-cmd-metrics] A
+full DMETA MUST include the definition of every Command-datatype metric the Device exposes, including
+its command argument and result definitions, so that Host Applications can invoke it via DCMD and
+process the DRESP response.*#
+* [tck-testable tck-id-payloads-dmeta-no-value]#[yellow-background]*[tck-id-payloads-dmeta-no-value] DMETA
+messages MUST NOT be used to convey current metric values.*#
+* [tck-testable tck-id-payloads-dmeta-qos]#[yellow-background]*[tck-id-payloads-dmeta-qos] DMETA
+messages MUST be published with the MQTT QoS set to 0.*#
+* [tck-testable tck-id-payloads-dmeta-retain]#[yellow-background]*[tck-id-payloads-dmeta-retain] A full
+DMETA MUST be published with the MQTT retain flag set to true.*#
+
+[[payloads_c_nmmeta]]
+==== NMMETA and DMMETA
+
+An NMMETA (for an Edge Node) or DMMETA (for a Device) conveys a change to the metric structure after
+it has been established - a metric added, removed, or modified - without requiring a full Rebirth. It
+carries only the affected metrics, each tagged with an operation, and is a live, non-retained,
+sequenced message. Because it is not retained, every NMMETA/DMMETA MUST be accompanied by an updated
+full NMETA/DMETA (retain true) so that the retained metadata always reflects the complete current
+structure.
+
+* [tck-testable tck-id-payloads-mmeta-qos]#[yellow-background]*[tck-id-payloads-mmeta-qos] NMMETA and
+DMMETA messages MUST be published with the MQTT QoS set to 0 and the MQTT retain flag set to false.*#
+* [tck-testable tck-id-payloads-mmeta-full]#[yellow-background]*[tck-id-payloads-mmeta-full] Every
+NMMETA MUST be accompanied by an updated full NMETA published with retain true, and every DMMETA by an
+updated full DMETA published with retain true, reflecting the complete metric structure after the
+change.*#
+* [tck-testable tck-id-payloads-mmeta-prev]#[yellow-background]*[tck-id-payloads-mmeta-prev] An
+NMMETA/DMMETA MUST include previous_definition_id equal to the definition identifier in effect
+immediately before the change, and definition_id equal to the identifier after applying the
+operations.*#
+* [tck-testable tck-id-payloads-mmeta-metrics]#[yellow-background]*[tck-id-payloads-mmeta-metrics] An
+NMMETA/DMMETA MUST include only the metrics affected by the change, and each MUST carry an operation
+of ADD, UPDATE, or DELETE.*#
+* [tck-testable tck-id-payloads-mmeta-add]#[yellow-background]*[tck-id-payloads-mmeta-add] An ADD
+metric MUST include the metric name and datatype and its definition fields, and MAY include an
+alias.*#
+* [tck-testable tck-id-payloads-mmeta-update]#[yellow-background]*[tck-id-payloads-mmeta-update] An
+UPDATE metric MUST be identified by its existing alias, if an alias was assigned, or otherwise by its
+name, and MUST include the complete new definition for that metric.*#
+* [tck-testable tck-id-payloads-mmeta-delete]#[yellow-background]*[tck-id-payloads-mmeta-delete] A
+DELETE metric MUST be identified by its existing alias, if an alias was assigned, or otherwise by its
+name.*#
+
 [[payloads_c_nbirth]]
 ==== NBIRTH
 
@@ -1210,21 +1351,29 @@ published.*#
 * [tck-testable tck-id-payloads-nbirth-edge-node-descriptor]#[yellow-background]*[tck-id-payloads-nbirth-edge-node-descriptor] Every
 Edge Node Descriptor in any Sparkplug infrastructure MUST be unique in the system.*#
 ** These are used like addresses and need to be unique as a result.
+* [tck-testable tck-id-payloads-nbirth-defid]#[yellow-background]*[tck-id-payloads-nbirth-defid] Every
+NBIRTH message MUST include a definition_id equal to the content hash of the NMETA that describes this
+Edge Node, and MUST report values only for metrics defined in that NMETA.*#
+* [tck-testable tck-id-payloads-nbirth-metrics]#[yellow-background]*[tck-id-payloads-nbirth-metrics] Each
+metric in the NBIRTH MUST include its current value and MUST be identified either by its alias, if an
+alias was assigned to it in the referenced NMETA, or otherwise by its metric name. The NBIRTH MUST
+NOT be used to convey metric datatype, properties, or metadata.*#
 * [tck-testable tck-id-payloads-nbirth-seq]#[yellow-background]*[tck-id-payloads-nbirth-seq] Every
-NBIRTH message MUST include a sequence number and it MUST have a value between 0 and
-18446744073709551615 (inclusive).*#
+NBIRTH message MUST include a sequence number. If no NMETA is published in the BIRTH sequence, the
+NBIRTH's sequence number MUST be 0; if an NMETA is published (sequence number 0), the NBIRTH's
+sequence number MUST be 1.*#
 * [tck-testable tck-id-payloads-nbirth-bdseq]#[yellow-background]*[tck-id-payloads-nbirth-bdseq] Every
-NBIRTH message MUST include a bdSeq number in the payload.*#
+NBIRTH message MUST include a bd_seq number in the payload.*#
 * [tck-testable tck-id-payloads-nbirth-bdseq-repeat]#[yellow-background]*[tck-id-payloads-nbirth-bdseq-repeat] The
-bdSeq number value MUST match the bdSeq number value that was sent in the prior MQTT CONNECT packet
+bd_seq number value MUST match the bd_seq number value that was sent in the prior MQTT CONNECT packet
 WILL Message.*#
 ** Note if a new NBIRTH is being sent for any reason, the Sparkplug Edge Node MQTT client MUST use
-the same bdSeq number in the payload that was sent in the prior MQTT CONNECT packet Will Message
-payload. This is because the NDEATH bdSeq number MUST always match the bdSeq number of the
+the same bd_seq number in the payload that was sent in the prior MQTT CONNECT packet Will Message
+payload. This is because the NDEATH bd_seq number MUST always match the bd_seq number of the
 associated NBIRTH that is stored in the MQTT Server via the MQTT Will Message.
-* [tck-testable tck-id-payloads-nbirth-rebirth-req]#[yellow-background]*[tck-id-payloads-nbirth-rebirth-req] Every
-NBIRTH message MUST include a metric with the name 'Node Control/Rebirth' and have a boolean value
-of false.*#
+* [tck-testable tck-id-payloads-nbirth-rebirth-req]#[yellow-background]*[tck-id-payloads-nbirth-rebirth-req] The
+Edge Node's NMETA MUST define a metric with the name 'Node Control/Rebirth' of datatype boolean, and
+every NBIRTH MUST report a value of false for that metric.*#
 ** This is used by Host Applications to force an Edge Node to send a new birth sequence (NREBIRTH
 and DREBIRTH messages) if errors are detected by a Host Application in the data stream.
 * [tck-testable tck-id-payloads-nbirth-qos]#[yellow-background]*[tck-id-payloads-nbirth-qos] NBIRTH
@@ -1250,54 +1399,46 @@ Consider the following Sparkplug B payload in the NBIRTH message shown above:
 ----
 {
         "timestamp": 1486144502122,
+        "definition_id": "9f2c...e2",
         "metrics": [{
                 "name": "Node Control/Reboot",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Node Control/Rebirth",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Node Control/Next Server",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Node Control/Scan Rate",
                 "timestamp": 1486144502122,
-                "dataType": "Int64",
                 "value": 3000
         }, {
                 "name": "Properties/Hardware Make",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Raspberry Pi"
         }, {
                 "name": "Properties/Hardware Model",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Pi 3 Model B"
         }, {
                 "name": "Properties/OS",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Raspbian"
         }, {
                 "name": "Properties/OS Version",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Jessie with PIXEL/11.01.2017"
         }, {
                 "name": "Supply Voltage",
                 "timestamp": 1486144502122,
-                "dataType": "Float",
                 "value": 12.1
         }],
         "seq": 0,
-        "bdSeq": 0
+        "bd_seq": 0
 }
 ----
 
@@ -1333,13 +1474,13 @@ NREBIRTH message MUST include a sequence number that is the following value:*#
 *** pds = Next pending DATA publish seq number
 *** dc = Device count (number of Sparkplug Devices under the scope of the Edge Node)
 * [tck-testable tck-id-payloads-nrebirth-bdseq]#[yellow-background]*[tck-id-payloads-nrebirth-bdseq] Every
-NREBIRTH message MUST include a bdSeq number value specified in the payload.*#
+NREBIRTH message MUST include a bd_seq number value specified in the payload.*#
 * [tck-testable tck-id-payloads-nrebirth-bdseq-repeat]#[yellow-background]*[tck-id-payloads-nrebirth-bdseq-repeat] The
-bdSeq number value MUST match the bdSeq number value that was sent in the immediately prior MQTT
+bd_seq number value MUST match the bd_seq number value that was sent in the immediately prior MQTT
 CONNECT packet WILL Message.*#
-** Note if a new NREBIRTH is being sent, the Sparkplug Edge Node MQTT client MUST use the same bdSeq
+** Note if a new NREBIRTH is being sent, the Sparkplug Edge Node MQTT client MUST use the same bd_seq
 number in the payload that was sent in the prior MQTT CONNECT packet Will Message payload. This is
-because the NDEATH bdSeq number MUST always match the bdSeq number of the associated NBIRTH that is
+because the NDEATH bd_seq number MUST always match the bd_seq number of the associated NBIRTH that is
 stored in the MQTT Server via the MQTT Will Message.
 * [tck-testable tck-id-payloads-nrebirth-rebirth-req]#[yellow-background]*[tck-id-payloads-nrebirth-rebirth-req] Every
 NREBIRTH message MUST include a metric with the name 'Node Control/Rebirth' and have a boolean value
@@ -1369,54 +1510,46 @@ Consider the following Sparkplug B payload in the NREBIRTH message shown above:
 ----
 {
         "timestamp": 1486144502122,
+        "definition_id": "9f2c...e2",
         "metrics": [{
                 "name": "Node Control/Reboot",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Node Control/Rebirth",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Node Control/Next Server",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Node Control/Scan Rate",
                 "timestamp": 1486144502122,
-                "dataType": "Int64",
                 "value": 3000
         }, {
                 "name": "Properties/Hardware Make",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Raspberry Pi"
         }, {
                 "name": "Properties/Hardware Model",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Pi 3 Model B"
         }, {
                 "name": "Properties/OS",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Raspbian"
         }, {
                 "name": "Properties/OS Version",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Jessie with PIXEL/11.01.2017"
         }, {
                 "name": "Supply Voltage",
                 "timestamp": 1486144502122,
-                "dataType": "Float",
                 "value": 12.1
         }],
         "seq": 0,
-        "bdSeq": 0
+        "bd_seq": 0
 }
 ----
 
@@ -1434,6 +1567,13 @@ device. This includes every metric it will publish data for in the future.
 * [tck-testable tck-id-payloads-dbirth-timestamp]#[yellow-background]*[tck-id-payloads-dbirth-timestamp] DBIRTH
 messages MUST include an overall payload timestamp that denotes the time at which the message was
 published.*#
+* [tck-testable tck-id-payloads-dbirth-defid]#[yellow-background]*[tck-id-payloads-dbirth-defid] Every
+DBIRTH message MUST include a definition_id equal to the content hash of the DMETA that describes this
+Device, and MUST report values only for metrics defined in that DMETA.*#
+* [tck-testable tck-id-payloads-dbirth-metrics]#[yellow-background]*[tck-id-payloads-dbirth-metrics] Each
+metric in the DBIRTH MUST include its current value and MUST be identified either by its alias, if an
+alias was assigned to it in the referenced DMETA, or otherwise by its metric name. The DBIRTH MUST
+NOT be used to convey metric datatype, properties, or metadata.*#
 * [tck-testable tck-id-payloads-dbirth-seq]#[yellow-background]*[tck-id-payloads-dbirth-seq] Every
 DBIRTH message MUST include a sequence number.*#
 * [tck-testable tck-id-payloads-dbirth-seq-inc]#[yellow-background]*[tck-id-payloads-dbirth-seq-inc] Every
@@ -1467,75 +1607,62 @@ Consider the following Sparkplug B payload in the DBIRTH message shown above:
 ----
 {
         "timestamp": 1486144502122,
+        "definition_id": "a1c9...77",
         "metrics": [{
                 "name": "Inputs/A",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Inputs/B",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Inputs/C",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Inputs/D",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Inputs/Button",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/E",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/F",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/G",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/H",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/LEDs/Green",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/LEDs/Red",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/LEDs/Yellow",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/Buzzer",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Properties/Hardware Make",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Pibrella"
         }],
         "seq": 1
@@ -1589,75 +1716,62 @@ Consider the following Sparkplug B payload in the DREBIRTH message shown above:
 ----
 {
         "timestamp": 1486144502122,
+        "definition_id": "a1c9...77",
         "metrics": [{
                 "name": "Inputs/A",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Inputs/B",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Inputs/C",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Inputs/D",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Inputs/Button",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/E",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/F",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/G",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/H",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/LEDs/Green",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/LEDs/Red",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/LEDs/Yellow",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Outputs/Buzzer",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": false
         }, {
                 "name": "Properties/Hardware Make",
                 "timestamp": 1486144502122,
-                "dataType": "String",
                 "value": "Pibrella"
         }],
         "seq": 1
@@ -1697,6 +1811,9 @@ have been published by the Edge Node.*#
 messages MUST be published with the MQTT QoS set to 0.*#
 * [tck-testable tck-id-payloads-ndata-retain]#[yellow-background]*[tck-id-payloads-ndata-retain] NDATA
 messages MUST be published with the MQTT retain flag set to false.*#
+* [tck-testable tck-id-payloads-ndata-defid]#[yellow-background]*[tck-id-payloads-ndata-defid] Every
+NDATA message MUST include a definition_id equal to the content hash of the NMETA that currently
+describes this Edge Node, and MUST identify each metric by its alias or name.*#
 
 The following is a representation of a simple NDATA message on the topic:
 
@@ -1715,10 +1832,10 @@ Consider the following Sparkplug B payload in the NDATA message shown above:
 ----
 {
         "timestamp": 1486144502122,
+        "definition_id": "9f2c...e2",
         "metrics": [{
                 "name": "Supply Voltage",
                 "timestamp": 1486144502122,
-                "dataType": "Float",
                 "value": 12.3
         }],
         "seq": 2
@@ -1755,6 +1872,9 @@ have been published by the Edge Node.*#
 messages MUST be published with the MQTT QoS set to 0.*#
 * [tck-testable tck-id-payloads-ddata-retain]#[yellow-background]*[tck-id-payloads-ddata-retain] DDATA
 messages MUST be published with the MQTT retain flag set to false.*#
+* [tck-testable tck-id-payloads-ddata-defid]#[yellow-background]*[tck-id-payloads-ddata-defid] Every
+DDATA message MUST include a definition_id equal to the content hash of the DMETA that currently
+describes this Device, and MUST identify each metric by its alias or name.*#
 
 The following is a representation of a simple DDATA message on the topic:
 
@@ -1770,15 +1890,14 @@ Consider the following Sparkplug B payload in the DDATA message shown above:
 ----
 {
         "timestamp": 1486144502122,
+        "definition_id": "a1c9...77",
         "metrics": [{
                 "name": "Inputs/A",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": true
         }, {
                 "name": "Inputs/C",
                 "timestamp": 1486144502122,
-                "dataType": "Boolean",
                 "value": true
         }],
         "seq": 0
@@ -2104,14 +2223,14 @@ NDEATH message MUST set the MQTT Will QoS to 1 in the MQTT CONNECT packet.*#
 * [tck-testable tck-id-payloads-ndeath-will-message-retain]#[yellow-background]*[tck-id-payloads-ndeath-will-message-retain] The
 NDEATH message MUST set the MQTT Will Retained flag to false in the MQTT CONNECT packet.*#
 * [tck-testable tck-id-payloads-ndeath-bdseq]#[yellow-background]*[tck-id-payloads-ndeath-bdseq] The
-NDEATH message MUST include the same bdSeq number value that will be used in the associated NBIRTH
-message.*#
+NDEATH message MUST include, as the payload bd_seq field, the same bd_seq number value that will be
+used in the associated NBIRTH message.*#
 ** This is used by Host Applications to correlate the NDEATH messages with a previously received NBIRTH
 message.
-** It is important to note that any new CONNECT packet must increment the bdSeq number in the
+** It is important to note that any new CONNECT packet must increment the bd_seq number in the
 payload compared to what was in the previous CONNECT packet. This ensures that any Host Applications
-will be able to distinguish between current and old bdSeq numbers in the event that messages are
-delivered out of order. When incrementing the bdSeq number, if the previous value was
+will be able to distinguish between current and old bd_seq numbers in the event that messages are
+delivered out of order. When incrementing the bd_seq number, if the previous value was
 18446744073709551615 (max value of a UINT64), the next value must be zero.
 * [tck-testable tck-id-payloads-ndeath-will-message-publisher]#[yellow-background]*[tck-id-payloads-ndeath-will-message-publisher] An
 NDEATH message SHOULD be published by the Edge Node before it intentionally disconnects from the
@@ -2132,7 +2251,7 @@ Server.
 * An NDEATH message MAY include a timestamp.
 ** It should be noted that this timestamp is typically set at the time of the MQTT CONNECT message
 and as a result may not be useful to Host Applications. If the timestamp is set, Host Applications
-SHOULD NOT use it to determine corresponding NBIRTH messages. Instead, the bdSeq number used in the
+SHOULD NOT use it to determine corresponding NBIRTH messages. Instead, the bd_seq number used in the
 NBIRTH, NREBIRTH, and NDEATH messages MUST be used to determine that an NDEATH matches a prior
 NBIRTH.
 
@@ -2151,11 +2270,11 @@ Consider the following Sparkplug B payload in the NDEATH message shown above:
 ----
 {
         "timestamp": 1486144502122,
-        "bdSeq": 0
+        "bd_seq": 0
 }
 ----
 
-The bdSeq number value in the payload allows a Host Application to reconcile this NDEATH with the
+The bd_seq number value in the payload allows a Host Application to reconcile this NDEATH with the
 NBIRTH and/or NREBIRTH that occurred previously.
 
 [[payloads_c_ddeath]]

--- a/specification/src/main/asciidoc/chapters/Sparkplug_8_HA.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_8_HA.adoc
@@ -137,7 +137,7 @@ plantuml::{assetsdir}assets/plantuml/primary-application-state-flow.puml[format=
 should issue a subscription to the Primary Host Application STATE message. The Edge Nodes are free
 to establish an MQTT Session to any of the available servers over any available network at any time
 and examine the current STATE online value. If the STATE message payload contains ‘online=false’ and
-the bdSeq number value in the paylaod matches the bdSeq number in the prior Host Application BIRTH
+the bd_seq number value in the paylaod matches the bd_seq number in the prior Host Application BIRTH
 message then the Edge Node should disconnect and walk to the next available server.
 . Upon startup, the configured Primary Application, the MQTT Session will be configured to register
 the Primary Host Application DEATH Certificate that indicates STATE is ‘online=false’ with the


### PR DESCRIPTION
# Sparkplug C: separate data & metadata in BIRTH messages, with modified-metadata (CRUD) support

Resolves **#445** and **#448**. Targets the Sparkplug C work on `develop`.

## Summary

Splits metric **definitions** (metadata) from metric **values** (data). This fills in the
`NMETA`/`DMETA` message types (currently only stubbed in the message-type list) with full topic and
payload definitions, adds `NMMETA`/`DMMETA` for post-BIRTH changes, and converts `NBIRTH`/`DBIRTH`
into value-only messages that reference the metadata by a recalculatable **definition identifier**.

## New / completed message types

- **`NMETA` / `DMETA`** — full metric definitions. Published **QoS 0, retain=true**, so the MQTT
  Server holds the current structure (including while the node is offline). Must define every metric
  the node/device will report on, including every **Command-datatype** metric (arguments/results) it
  exposes.
- **`NMMETA` / `DMMETA`** — "modified metadata": only the added/updated/deleted metrics, each tagged
  `ADD`/`UPDATE`/`DELETE`. Published retain=false, and always accompanied by an updated full
  `NMETA`/`DMETA` (retain=true) so the retained copy stays complete.

## Key mechanics

- **Definition identifier** = SHA-256 over an RFC 8785 (JCS) canonicalization of a value-free
  metadata projection. Correlates values↔structure and lets consumers self-verify / detect drift.
- **Value-only BIRTH/DATA** identify each metric by **name or alias** (aliases optional);
  datatype/properties/metadata live only in the metadata messages.
- **Discovery via native MQTT retain** — the Sparkplug Aware MQTT Server no longer stores
  NBIRTHs/DBIRTHs or republishes `$sparkplug/certificates`.
- **Reconnect optimization** — the node subscribes to its own NMETA/DMETA topic and (re)publishes
  only if the Server lacks a copy with the current definition identifier.
- **Sequencing** — the first BIRTH-sequence message is `seq` 0 (`NMETA` if published, else `NBIRTH`);
  all subsequent Edge-Node messages increment (rollover at UINT64 max). Reuses the existing
  payload-level `bd_seq` field on every Edge-Node message.
- **Rebirth** — reuses the existing `REBIRTH`/`NREBIRTH`/`DREBIRTH` verbs where a Rebirth is required.

## Protobuf (Sparkplug C payload)

Added `MetricOperation` enum + `Metric.operation`, and `Payload.definition_id` /
`previous_definition_id`. Uses the existing `Payload.bd_seq` field.

## Chapters touched

`Sparkplug_4_Topics`, `Sparkplug_5_Operational_Behavior`, `Sparkplug_6_Payloads`,
`Sparkplug_10_Conformance`. All new normative statements carry `tck-id`s; the
`asciidoctorDocbook` → `xsltAudit` → normative-statements build passes.

## Open items for WG

- Exact canonical serialization for the definition-identifier hash (field ordering, Template members,
  Unicode normalization) so independent implementations produce identical hashes.
- Alias-reuse policy for deleted metrics.
