### PR TITLE
[#553] Always include a bdSeq number for scoping messages to a session

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -599,6 +599,8 @@ payload.*#
 * [tck-testable tck-id-topics-ndata-payload]#[yellow-background]*[tck-id-topics-ndata-payload] The
 NDATA MUST include the Edge Node’s metrics that have changed since the last NBIRTH or NDATA
 message.*#
+* [tck-testable tck-id-topics-ndata-bdseq]#[yellow-background]*[tck-id-topics-ndata-bdseq] The
+NDATA MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
 
 [[death_message_ndeath]]
 ===== Death Message (NDEATH)
@@ -701,6 +703,8 @@ MQTT client.*#
 NRESP MUST include the correlation_id from the NCMD Command Request that it is responding to.*#
 * [tck-testable tck-id-topics-nresp-payload-status]#[yellow-background]*[tck-id-topics-nresp-payload-status] The
 NRESP MUST include a status for the command that it is responding to.*#
+* [tck-testable tck-id-topics-nresp-bdseq]#[yellow-background]*[tck-id-topics-nresp-bdseq] The
+NRESP MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
 
 [[topics_device]]
 ==== Device
@@ -853,6 +857,8 @@ identifier.*#
 * [tck-testable tck-id-topics-dbirth-no-metadata]#[yellow-background]*[tck-id-topics-dbirth-no-metadata] The
 DBIRTH MUST NOT be used to convey metric datatype, properties, or metadata. These are conveyed only
 in the DMETA and DMMETA.*#
+* [tck-testable tck-id-topics-dbirth-bdseq]#[yellow-background]*[tck-id-topics-dbirth-bdseq] The
+DBIRTH MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
 
 The DBIRTH message can also include optional ‘Device Control’ payload components. These are used by
 a Host Application to control aspects of a device. The following are examples of Device Control
@@ -939,6 +945,8 @@ identifier.*#
 * [tck-testable tck-id-topics-drebirth-no-metadata]#[yellow-background]*[tck-id-topics-drebirth-no-metadata] The
 DREBIRTH MUST NOT be used to convey metric datatype, properties, or metadata. These are conveyed only
 in the DMETA and DMMETA.*#
+* [tck-testable tck-id-topics-drebirth-bdseq]#[yellow-background]*[tck-id-topics-drebirth-bdseq] The
+DREBIRTH MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
 
 The DREBIRTH message can also include optional ‘Device Control’ payload components. These are used
 by a Host Application to control aspects of a device. The following are examples of Device Control
@@ -1002,6 +1010,8 @@ individual Metric in the payload MAY include its own timestamp. If it does not, 
 payload.*#
 * [tck-testable tck-id-topics-ddata-payload]#[yellow-background]*[tck-id-topics-ddata-payload] The
 DDATA MUST include the Device’s metrics that have changed since the last DBIRTH or DDATA message.*#
+* [tck-testable tck-id-topics-ddata-bdseq]#[yellow-background]*[tck-id-topics-ddata-bdseq] The
+DDATA MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
 
 [[death_message_ddeath]]
 ===== Death Message (DDEATH)
@@ -1037,6 +1047,8 @@ messages MUST be published with MQTT QoS equal to 0 and retain equal to false.*#
 DDEATH MUST include a sequence number in the payload and it MUST have a value of one greater than
 the previous MQTT message from the Edge Node contained unless the previous MQTT message contained a
 value of 18446744073709551615 (max value of a UINT64). In this case the sequence number MUST be 0.*#
+* [tck-testable tck-id-topics-ddeath-bdseq]#[yellow-background]*[tck-id-topics-ddeath-bdseq] The
+DDEATH MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
 
 [[command_dcmd]]
 ===== Command (DCMD)
@@ -1103,6 +1115,8 @@ MQTT client.*#
 DRESP MUST include the correlation_id from the DCMD Command Request that it is responding to.*#
 * [tck-testable tck-id-topics-dresp-payload-status]#[yellow-background]*[tck-id-topics-dresp-payload-status] The
 DRESP MUST include a status for the command that it is responding to.*#
+* [tck-testable tck-id-topics-dresp-bdseq]#[yellow-background]*[tck-id-topics-dresp-bdseq] The
+DRESP MUST include a bd_seq number matching the bd_seq of the current MQTT session.*#
 
 [[topics_sparkplug_host_application]]
 [upperalpha, start=1]

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -804,18 +804,18 @@ descriptor_seq, and MUST NOT treat the absence of those fields as a malformed pa
 any sequence stream.*#
 ** Non-normative comment: an NDEATH delivered by the MQTT Server as the Edge Node's registered Will
 Message carries neither sequence number, whereas an NDEATH published directly by the Edge Node
-carries both. In either form, the NDEATH means that the Edge Node session identified by the bd_seq
-number in its payload has ended. It does not by itself mean the Edge Node is offline now, since a
-subsequent session may already have been established.
+carries both. Both forms carry a bd_seq number, so both can be correlated to a session. In either
+form, the NDEATH means that the Edge Node session identified by the bd_seq number in its payload has
+ended. It does not by itself mean the Edge Node is offline now, since a subsequent session may already
+have been established.
 * [tck-testable tck-id-operational-behavior-host-partial-ndeath-bdseq-correlate]#[yellow-background]*[tck-id-operational-behavior-host-partial-ndeath-bdseq-correlate] A
 Host Application with partial subscriptions MUST correlate an incoming NDEATH to the Sparkplug session
-it holds for that Edge Node by matching the NDEATH's bd_seq number against the bd_seq number carried in
-the NMETA, NBIRTH, and NREBIRTH messages it received for that session. It MUST NOT rely on the
-NDEATH's timestamp, which is typically set at MQTT CONNECT time and does not indicate when the Edge
-Node went offline.*#
-** All three of the NMETA, NBIRTH, and NREBIRTH carry the bd_seq number of the MQTT session they were
-published in, so any of them establishes the bd_seq number that the terminating NDEATH will carry. A
-Host Application that holds only some of them still holds the session's bd_seq number.
+it holds for that Edge Node by matching the NDEATH's bd_seq number against the bd_seq number of that
+session. It MUST NOT rely on the NDEATH's timestamp, which is typically set at MQTT CONNECT time and
+does not indicate when the Edge Node went offline.*#
+** Every message an Edge Node publishes carries the bd_seq number of the session it was published in,
+so a Host Application learns a session's bd_seq number from whichever messages it happens to subscribe
+to. It does not need to have received any particular message type to be able to correlate the NDEATH.
 * [tck-testable tck-id-operational-behavior-host-partial-ndeath-bdseq-mismatch]#[yellow-background]*[tck-id-operational-behavior-host-partial-ndeath-bdseq-mismatch] A
 Host Application with partial subscriptions MUST NOT mark its Devices of interest offline on an NDEATH
 whose bd_seq number does not match the bd_seq number of the Sparkplug session it currently holds for
@@ -897,6 +897,27 @@ link:#operational_behavior_host_application_message_ordering[Sparkplug Host Appl
 Ordering] section MUST be applied per Sparkplug Descriptor when a Host Application is tracking
 descriptor_seq, and a Reorder Timeout on one Descriptor's stream MUST NOT be interpreted as a gap on
 any other Descriptor's stream.*#
+
+Because every message an Edge Node publishes carries the bd_seq number of its MQTT session, a Host
+Application with partial subscriptions can attribute any single message it receives to a session,
+without having had to observe the BIRTH sequence that opened it. A descriptor sequence stream is scoped
+to one session, so the bd_seq number is what tells a Host Application whether a descriptor_seq value it
+receives belongs to the stream it is currently tracking.
+
+* [tck-testable tck-id-operational-behavior-host-partial-bdseq-scope]#[yellow-background]*[tck-id-operational-behavior-host-partial-bdseq-scope] A
+Host Application with partial subscriptions MUST use the bd_seq number of each message it receives to
+determine which Edge Node session that message belongs to, and MUST NOT apply a message to the session
+state it holds unless the message's bd_seq number matches the bd_seq number of that held session.*#
+* [tck-testable tck-id-operational-behavior-host-partial-bdseq-new-session]#[yellow-background]*[tck-id-operational-behavior-host-partial-bdseq-new-session] If
+a Host Application with partial subscriptions receives a message whose bd_seq number does not match the
+session it holds for that Edge Node, and it has not received a BIRTH sequence for the session that
+message identifies, it MUST treat its held session state for that Edge Node as no longer valid and
+SHOULD issue a Rebirth Request to resynchronize.*#
+** Non-normative comment: this is the situation a Host Application with partial subscriptions is in when
+it starts up while an Edge Node is already running, or when the Edge Node reconnects while the Host
+Application is not subscribed to that Edge Node's NBIRTH. The bd_seq number makes the condition
+detectable from the first message received, rather than only becoming apparent when descriptor_seq
+values stop making sense.
 
 A Host Application also has to establish where in a descriptor sequence stream it is starting from.
 A BIRTH begins a stream and carries a descriptor_seq of 0. A REBIRTH does not begin a stream; it

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -328,7 +328,7 @@ message Payload {
     optional uint64   timestamp     = 1;        // Timestamp at message sending time
     repeated Metric   metrics       = 2;        // Repeated forever - no limit in Google Protobufs
     optional uint64   seq           = 3;        // Message sequence number - ordered stream of all messages from the Edge Node
-    optional uint64   bd_seq        = 4;        // The Birth/Death sequence number for BIRTH and DEATH payloads
+    optional uint64   bd_seq        = 4;        // The Birth/Death sequence number - scopes this message to the MQTT session it was published in
     optional string   source        = 5;        // Source for CMD and REBIRTH messages - the Host Application ID that sent the message
     optional string   uuid          = 6;        // UUID to track message type in terms of schema definitions
     optional bytes    body          = 7;        // To optionally bypass the whole definition above
@@ -350,15 +350,15 @@ JSON as follows:
 
 ----
 {
-        "timestamp": <timestamp>,
-        "metrics": [{
-                "name": <metric_name>,
-                "alias": <alias>,
-                "timestamp": <timestamp>,
-                "dataType": <datatype>,
-                "value": <value>
-        }],
-        "seq": <sequence_number>
+        "timestamp": <timestamp>,
+        "metrics": [{
+                "name": <metric_name>,
+                "alias": <alias>,
+                "timestamp": <timestamp>,
+                "dataType": <datatype>,
+                "value": <value>
+        }],
+        "seq": <sequence_number>
 }
 ----
 
@@ -366,15 +366,15 @@ A simple Sparkplug B payload with values would be represented as follows:
 
 ----
 {
-        "timestamp": 1486144502122,
-        "metrics": [{
-                "name": "My Metric",
-                "alias": 1,
-                "timestamp": 1479123452194,
-                "dataType": "String",
-                "value": "Test"
-        }],
-        "seq": 2
+        "timestamp": 1486144502122,
+        "metrics": [{
+                "name": "My Metric",
+                "alias": 1,
+                "timestamp": 1479123452194,
+                "dataType": "String",
+                "value": "Test"
+        }],
+        "seq": 2
 }
 ----
 
@@ -445,19 +445,40 @@ subsequent messages after an NBIRTH from an Edge Node MUST contain a sequence nu
 continually increasing by one in each message from that Edge Node until a value of
 18446744073709551615 (max value of a UINT64) is reached. At that point, the sequence number of the
 following message MUST be zero.*#
-** _seq_
-*** This is the birth/death sequence number which is an unsigned 64-bit integer.
+** _bd_seq_
+*** This is the birth/death sequence number which is an unsigned 64-bit integer. It scopes a message to
+the MQTT session in which it was published. Unlike seq and descriptor_seq, which advance from message
+to message, the bd_seq number is constant for the lifetime of an MQTT session and changes only when a
+new session is established.
 **** [tck-testable tck-id-payloads-bd-sequence-num-included]#[yellow-background]*[tck-id-payloads-bd-sequence-num-included] A
-birth/death sequence number MUST be included in the payload of every NBIRTH, NREBIRTH, and NDEATH
-Sparkplug MQTT message from an Edge Node.*#
+birth/death sequence number MUST be included in the payload of every Sparkplug MQTT message published
+by an Edge Node, including an NDEATH delivered by the MQTT Server as the Edge Node's registered MQTT
+Will Message.*#
+***** This means the NMETA, NMMETA, NBIRTH, NREBIRTH, NDATA, NRESP, NDEATH, DMETA, DMMETA, DBIRTH,
+DREBIRTH, DDATA, DRESP, and DDEATH messages all carry a bd_seq number.
+***** Non-normative comment: a Will-delivered NDEATH carries neither a seq nor a descriptor_seq,
+because the MQTT Server cannot know the Edge Node's current position in either stream when it releases
+the Will Message. It does carry a bd_seq number, because that value is fixed for the whole session and
+is therefore known when the Will Message is registered in the MQTT CONNECT packet.
+***** Non-normative comment: messages published by Sparkplug Host Applications rather than by Edge
+Nodes (NCMD, DCMD, REBIRTH, and STATE) do not carry a bd_seq number.
 **** [tck-testable tck-id-payloads-bd-sequence-num-req-nbirth]#[yellow-background]*[tck-id-payloads-bd-sequence-num-req-nbirth] Every
 birth/death sequence number included in the payload from an Edge Node MUST always be between 0 and
 18446744073709551615 (inclusive).*#
-**** [tck-testable tck-id-payloads-bd-sequence-num-incrementing]#[yellow-background]*[tck-id-payloads-bd-sequence-num-incrementing] All
-subsequent messages after an NBIRTH from an Edge Node MUST contain a birth/death sequence number
-that is continually increasing by one in each message from that Edge Node until a value of
-18446744073709551615 (max value of a UINT64) is reached. At that point, the sequence number of the
-following message MUST be zero.*#
+**** [tck-testable tck-id-payloads-bd-sequence-num-session-constant]#[yellow-background]*[tck-id-payloads-bd-sequence-num-session-constant] Every
+message an Edge Node publishes within a single MQTT session MUST carry the same birth/death sequence
+number, and that value MUST be the one registered in the Will Message payload of that session's MQTT
+CONNECT packet.*#
+***** Non-normative comment: this is what makes the bd_seq number a session identifier. Any single
+message from an Edge Node can be attributed to the session that produced it, and a Host Application can
+discard a message belonging to a session it has already replaced.
+**** [tck-testable tck-id-payloads-bd-sequence-num-incrementing]#[yellow-background]*[tck-id-payloads-bd-sequence-num-incrementing] The
+birth/death sequence number MUST start at zero and MUST increment by one on every new MQTT CONNECT
+packet sent by the Edge Node, until a value of 18446744073709551615 (max value of a UINT64) is reached.
+At that point the birth/death sequence number of the following MQTT CONNECT packet MUST be zero.*#
+***** Non-normative comment: the bd_seq number is not incremented from message to message within a
+session, and it is not incremented by an NREBIRTH, because an NREBIRTH does not establish a new MQTT
+session.
 ** _descriptor_seq_
 *** This is the descriptor sequence number which is an unsigned 64-bit integer. It is an ordered
 sequence number stream scoped to a single Sparkplug Descriptor (see the
@@ -1451,46 +1472,46 @@ Consider the following Sparkplug B payload in the NBIRTH message shown above:
 
 ----
 {
-        "timestamp": 1486144502122,
-        "definition_id": "9f2c...e2",
-        "metrics": [{
-                "name": "Node Control/Reboot",
-                "timestamp": 1486144502122,
-                "value": false
-        }, {
-                "name": "Node Control/Rebirth",
-                "timestamp": 1486144502122,
-                "value": false
-        }, {
-                "name": "Node Control/Next Server",
-                "timestamp": 1486144502122,
-                "value": false
-        }, {
-                "name": "Node Control/Scan Rate",
-                "timestamp": 1486144502122,
-                "value": 3000
-        }, {
-                "name": "Properties/Hardware Make",
-                "timestamp": 1486144502122,
-                "value": "Acme"
-        }, {
-                "name": "Properties/Hardware Model",
-                "timestamp": 1486144502122,
-                "value": "EdgeGate 2000"
-        }, {
-                "name": "Properties/OS",
-                "timestamp": 1486144502122,
-                "value": "Linux"
-        }, {
-                "name": "Properties/OS Version",
-                "timestamp": 1486144502122,
-                "value": "6.1"
-        }, {
-                "name": "Supply Voltage",
-                "timestamp": 1486144502122,
-                "value": 12.1
-        }],
-        "seq": 0,
+        "timestamp": 1486144502122,
+        "definition_id": "9f2c...e2",
+        "metrics": [{
+                "name": "Node Control/Reboot",
+                "timestamp": 1486144502122,
+                "value": false
+        }, {
+                "name": "Node Control/Rebirth",
+                "timestamp": 1486144502122,
+                "value": false
+        }, {
+                "name": "Node Control/Next Server",
+                "timestamp": 1486144502122,
+                "value": false
+        }, {
+                "name": "Node Control/Scan Rate",
+                "timestamp": 1486144502122,
+                "value": 3000
+        }, {
+                "name": "Properties/Hardware Make",
+                "timestamp": 1486144502122,
+                "value": "Acme"
+        }, {
+                "name": "Properties/Hardware Model",
+                "timestamp": 1486144502122,
+                "value": "EdgeGate 2000"
+        }, {
+                "name": "Properties/OS",
+                "timestamp": 1486144502122,
+                "value": "Linux"
+        }, {
+                "name": "Properties/OS Version",
+                "timestamp": 1486144502122,
+                "value": "6.1"
+        }, {
+                "name": "Supply Voltage",
+                "timestamp": 1486144502122,
+                "value": 12.1
+        }],
+        "seq": 0,
         "bd_seq": 0
 }
 ----
@@ -1570,46 +1591,46 @@ Consider the following Sparkplug B payload in the NREBIRTH message shown above:
 
 ----
 {
-        "timestamp": 1486144502122,
-        "definition_id": "9f2c...e2",
-        "metrics": [{
-                "name": "Node Control/Reboot",
-                "timestamp": 1486144502122,
-                "value": false
-        }, {
-                "name": "Node Control/Rebirth",
-                "timestamp": 1486144502122,
-                "value": false
-        }, {
-                "name": "Node Control/Next Server",
-                "timestamp": 1486144502122,
-                "value": false
-        }, {
-                "name": "Node Control/Scan Rate",
-                "timestamp": 1486144502122,
-                "value": 3000
-        }, {
-                "name": "Properties/Hardware Make",
-                "timestamp": 1486144502122,
-                "value": "Acme"
-        }, {
-                "name": "Properties/Hardware Model",
-                "timestamp": 1486144502122,
-                "value": "EdgeGate 2000"
-        }, {
-                "name": "Properties/OS",
-                "timestamp": 1486144502122,
-                "value": "Linux"
-        }, {
-                "name": "Properties/OS Version",
-                "timestamp": 1486144502122,
-                "value": "6.1"
-        }, {
-                "name": "Supply Voltage",
-                "timestamp": 1486144502122,
-                "value": 12.1
-        }],
-        "seq": 0,
+        "timestamp": 1486144502122,
+        "definition_id": "9f2c...e2",
+        "metrics": [{
+                "name": "Node Control/Reboot",
+                "timestamp": 1486144502122,
+                "value": false
+        }, {
+                "name": "Node Control/Rebirth",
+                "timestamp": 1486144502122,
+                "value": false
+        }, {
+                "name": "Node Control/Next Server",
+                "timestamp": 1486144502122,
+                "value": false
+        }, {
+                "name": "Node Control/Scan Rate",
+                "timestamp": 1486144502122,
+                "value": 3000
+        }, {
+                "name": "Properties/Hardware Make",
+                "timestamp": 1486144502122,
+                "value": "Acme"
+        }, {
+                "name": "Properties/Hardware Model",
+                "timestamp": 1486144502122,
+                "value": "EdgeGate 2000"
+        }, {
+                "name": "Properties/OS",
+                "timestamp": 1486144502122,
+                "value": "Linux"
+        }, {
+                "name": "Properties/OS Version",
+                "timestamp": 1486144502122,
+                "value": "6.1"
+        }, {
+                "name": "Supply Voltage",
+                "timestamp": 1486144502122,
+                "value": 12.1
+        }],
+        "seq": 0,
         "bd_seq": 0
 }
 ----
@@ -1709,7 +1730,8 @@ Consider the following Sparkplug B payload in the DBIRTH message shown above:
                 "timestamp": 1486144502122,
                 "value": "Acme"
         }],
-        "seq": 1
+        "seq": 1,
+        "bd_seq": 0
 }
 ----
 
@@ -1806,7 +1828,8 @@ Consider the following Sparkplug B payload in the DREBIRTH message shown above:
                 "timestamp": 1486144502122,
                 "value": "Acme"
         }],
-        "seq": 1
+        "seq": 1,
+        "bd_seq": 0
 }
 ----
 
@@ -1863,14 +1886,15 @@ Consider the following Sparkplug B payload in the NDATA message shown above:
 
 ----
 {
-        "timestamp": 1486144502122,
-        "definition_id": "9f2c...e2",
-        "metrics": [{
-                "name": "Supply Voltage",
-                "timestamp": 1486144502122,
-                "value": 12.3
-        }],
-        "seq": 2
+        "timestamp": 1486144502122,
+        "definition_id": "9f2c...e2",
+        "metrics": [{
+                "name": "Supply Voltage",
+                "timestamp": 1486144502122,
+                "value": 12.3
+        }],
+        "seq": 2,
+        "bd_seq": 0
 }
 ----
 
@@ -1932,7 +1956,8 @@ Consider the following Sparkplug B payload in the DDATA message shown above:
                 "timestamp": 1486144502122,
                 "value": 120
         }],
-        "seq": 0
+        "seq": 0,
+        "bd_seq": 0
 }
 ----
 
@@ -2180,7 +2205,8 @@ Consider the following Sparkplug B payload in the NRESP message shown above:
                                 "value": 0.125
                         }]
                 }
-        }]
+        }],
+        "bd_seq": 0
 }
 ----
 
@@ -2232,7 +2258,8 @@ Consider the following Sparkplug B payload in the DRESP message shown above:
                                 "message": "Device busy"
                         }
                 }
-        }]
+        }],
+        "bd_seq": 0
 }
 ----
 
@@ -2349,7 +2376,8 @@ Consider the following Sparkplug B payload in the DDEATH message shown above:
 ----
 {
         "timestamp": 1486144502122,
-        "seq": 123
+        "seq": 123,
+        "bd_seq": 0
 }
 ----
 


### PR DESCRIPTION
Require bd_seq in every message an Edge Node publishes, so any single message can be attributed to the session that produced it. Adds *-bdseq statements for NDATA, NRESP, DBIRTH, DREBIRTH, DDATA, DRESP, and DDEATH.

Corrects two blocking defects:
- payloads-bd-sequence-num-included named only NBIRTH/NREBIRTH/NDEATH and did not cover the NMETA/NMMETA/DMETA/DMMETA that Ch4 already required.
- payloads-bd-sequence-num-incrementing described seq behavior (increment per message), contradicting topics-nbirth-bdseq-increment and operational-behavior-rebirth-action-3. Now increments per MQTT CONNECT.

Adds payloads-bd-sequence-num-session-constant for the session invariant, renames the mislabelled _seq_ payload field description to _bd_seq_, and adds host-partial-bdseq-scope and host-partial-bdseq-new-session so a partial-subscription Host Application can scope a message to a session without having observed the BIRTH sequence that opened it.

Also normalizes 696 non-breaking spaces used as indentation in Ch6 example payloads; all 15 example payloads now parse as valid JSON.