### PR TITLE
[IMM-547] Added statements to protect against PHID bad actors and mis-configuration of PHID

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_4_Topics.adoc
@@ -1172,9 +1172,13 @@ Server immediately after successfully subscribing its own spCv4.0/STATE/sparkplu
 ====== Birth Certificate Payload (STATE)
 
 * [tck-testable tck-id-host-topic-phid-birth-payload]#[yellow-background]*[tck-id-host-topic-phid-birth-payload] The
-Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where the
-one key MUST be 'online' and it's value is a boolean 'true'. The other key MUST be 'timestamp' and
-the value MUST be a numeric value representing the current UTC time in nanoseconds since Epoch.*#
+Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include four key/value pairs. One key
+MUST be 'online' and it's value is a boolean 'true'. One key MUST be 'timestamp' and the value MUST
+be a numeric value representing the current UTC time in nanoseconds since Epoch. One key MUST be
+'bd_seq' and the value MUST be as defined in the link:#payloads_c_state_bd_seq[STATE bd_seq Number]
+section. One key MUST be 'client_id' and the value MUST be the MQTT Client ID of the MQTT session in
+which the message was published, as defined in the link:#payloads_c_state_client_id[STATE client_id]
+section.*#
 * [tck-testable tck-id-host-topic-phid-birth-payload-timestamp]#[yellow-background]*[tck-id-host-topic-phid-birth-payload-timestamp] The
 timestamp metric value MUST be the same timestamp value set in the immediately prior MQTT CONNECT
 packet's Will Message payload.*#
@@ -1209,9 +1213,13 @@ Sparkplug Host Application MUST provide a Will message in the MQTT CONNECT packe
 ====== Death Certificate Payload (STATE)
 
 * [tck-testable tck-id-host-topic-phid-death-payload]#[yellow-background]*[tck-id-host-topic-phid-death-payload] The
-STATE Death Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where
-one key MUST be 'online' and it's value is a boolean 'false'. The other key MUST be 'timestamp' and
-the value MUST be a numeric value representing the current UTC time in nanoseconds since Epoch.*#
+STATE Death Certificate Payload MUST be JSON UTF-8 data. It MUST include four key/value pairs. One
+key MUST be 'online' and it's value is a boolean 'false'. One key MUST be 'timestamp' and the value
+MUST be a numeric value representing the current UTC time in nanoseconds since Epoch. One key MUST
+be 'bd_seq' and the value MUST be as defined in the link:#payloads_c_state_bd_seq[STATE bd_seq
+Number] section. One key MUST be 'client_id' and the value MUST be the MQTT Client ID of the MQTT
+session in which the message was published, as defined in the link:#payloads_c_state_client_id[STATE
+client_id] section.*#
 * [tck-testable tck-id-host-topic-phid-death-payload-timestamp-connect]#[yellow-background]*[tck-id-host-topic-phid-death-payload-connect] The
 Death Certificate's used in the MQTT CONNECT packet Will message MUST use a timestamp value that
 represents the current UTC time at the time of the CONNECT packet is sent to the MQTT Server.*#

--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -112,6 +112,35 @@ the defined Sparkplug Topic Namespace.
 [tck-testable tck-id-message-flow-phid-sparkplug-subscription]#[yellow-background]*[tck-id-message-flow-phid-sparkplug-subscription] The
 subscription on the Sparkplug Topic Namespace and the STATE topic MUST be done immediately after
 successfully establishing the MQTT session and before publishing its own STATE message.*#
++
+[tck-testable tck-id-message-flow-phid-sparkplug-subscription-retain-options]#[yellow-background]*[tck-id-message-flow-phid-sparkplug-subscription-retain-options] A
+Sparkplug Host Application using MQTT 5.0 MUST subscribe to its own STATE topic with the 'Retain As
+Published' subscription option set to 0 and the 'Retain Handling' subscription option set to 0, and
+MUST NOT use a Shared Subscription for its own STATE topic.*#
++
+[tck-testable tck-id-message-flow-phid-sparkplug-subscription-no-local]#[yellow-background]*[tck-id-message-flow-phid-sparkplug-subscription-no-local] A
+Sparkplug Host Application using MQTT 5.0 MAY subscribe to its own STATE topic with the 'No Local'
+subscription option set to either 0 or 1.*#
++
+Non-normative comment: with 'No Local' set to 1 the MQTT Server does not deliver a Host
+Application's own published messages back to it, so the Host Application is delivered only STATE
+messages published by other MQTT clients and by the MQTT Server on its behalf. With 'No Local' set
+to 0, which is the MQTT 5.0 default and the only behavior MQTT 3.1.1 provides, the Host Application
+is also delivered the STATE messages it publishes itself and has to recognize them, as required in
+the link:#operational_behavior_host_application_own_state[Host Application Handling of STATE
+Messages on its Own Host Application ID] section. Both are conformant, and the externally observable
+behavior of the Host Application is the same either way.
++
+Non-normative comment: these are the MQTT 5.0 defaults, and they are the behavior MQTT 3.1.1 always
+provides. They are stated explicitly because the Host Application relies on the RETAIN flag of a
+delivered STATE message to tell a retained value from a live publish, as described in the
+link:#operational_behavior_host_application_own_state[Host Application Handling of STATE Messages on
+its Own Host Application ID] section. With 'Retain As Published' set to 1 the MQTT Server would
+preserve the publisher's RETAIN flag, and because STATE messages are always published with the
+retain flag set, every delivered STATE message would arrive with RETAIN set to 1 and the distinction
+would be lost. With 'Retain Handling' set to 2 the Host Application would never be delivered the
+retained value on its own STATE topic, and MQTT 5.0 does not deliver retained messages to Shared
+Subscriptions at all.
 
 . [tck-testable tck-id-message-flow-phid-sparkplug-state-publish]#[yellow-background]*[tck-id-message-flow-phid-sparkplug-state-publish] Once
 an MQTT Session has been established, the Sparkplug Host Application subscriptions on the Sparkplug
@@ -119,10 +148,13 @@ Topic Namespace have been established and the STATE topic subscription has been 
 Sparkplug Host Application MUST publish a new STATE message.*#
 +
 [tck-testable tck-id-message-flow-phid-sparkplug-state-publish-payload]#[yellow-background]*[tck-id-message-flow-phid-sparkplug-state-publish-payload] The
-Host Application Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value
-pairs where one key MUST be 'online' and its value is a boolean 'true'. The other key MUST be
-'timestamp' and the value MUST be the same value set in the immediately prior MQTT CONNECT packet's
-Will Message payload.*#
+Host Application Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include four key/value
+pairs. One key MUST be 'online' and its value is a boolean 'true'. One key MUST be 'timestamp' and
+the value MUST be the same value set in the immediately prior MQTT CONNECT packet's Will Message
+payload. One key MUST be 'bd_seq' and the value MUST be as defined in the
+link:#payloads_c_state_bd_seq[STATE bd_seq Number] section. One key MUST be 'client_id' and the
+value MUST be the MQTT Client ID of the MQTT session in which the message was published, as defined
+in the link:#payloads_c_state_client_id[STATE client_id] section.*#
 +
 [tck-testable tck-id-message-flow-phid-sparkplug-state-publish-payload-timestamp]#[yellow-background]*[tck-id-message-flow-phid-sparkplug-state-publish-payload-timestamp] The
 timestamp value in the Host Application Birth Certificate payload MUST be the same value set in the
@@ -142,12 +174,238 @@ Application.
 was connected to that MQTT Server and known by the Host Application MUST be updated to a STALE data
 quality if the Host Application loses connection to the MQTT Server.*#
 
-[tck-testable tck-id-message-flow-hid-sparkplug-state-message-delivered]#[yellow-background]*[tck-id-message-flow-hid-sparkplug-state-message-delivered] After
-publishing its own Host Application online STATE message, if at any point the Host Application is delivered
-a STATE message on its own Host Application ID with a timestamp that is newer than the timestamp
-that was used in its own immediately prior MQTT CONNECT packet Will Message, it MUST immediately
-disconnect from the MQTT Server and reconnect. It MUST follow the standard rules for Host
-Applications when establishing the connection to the MQTT Server.*#
+[[operational_behavior_host_application_own_state]]
+=== Host Application Handling of STATE Messages on its Own Host Application ID
+
+A Sparkplug Host Application subscribes to its own STATE topic, so it is delivered every STATE
+message published on its own Host Application ID, including messages it did not publish itself.
+Because the STATE topic is published with the MQTT retain flag set, and because any MQTT client with
+publish access to that topic can overwrite the retained value, a Host Application has to be able to
+tell its own session state from a stale value or from a value published by another client, and to
+restore the retained value when it has been displaced.
+
+Throughout this section, _T_ refers to the timestamp value the Host Application used in the Will
+Message payload of its immediately prior MQTT CONNECT packet to a given MQTT Server, which is also
+the timestamp value in the online STATE message it published to that MQTT Server.
+
+[[operational_behavior_host_application_own_state_will_invariant]]
+==== The Will Message Timestamp Invariant
+
+The Will Message payload is fixed when the MQTT CONNECT packet is sent and cannot be changed for the
+lifetime of that MQTT session. This constrains how a Host Application may correct its retained
+STATE.
+
+* [tck-testable tck-id-operational-behavior-hid-state-will-invariant]#[yellow-background]*[tck-id-operational-behavior-hid-state-will-invariant] The
+timestamp value in a Sparkplug Host Application's registered Will Message payload MUST be greater
+than or equal to the timestamp value of the most recent online STATE message the Host Application
+has published on that MQTT Server.*#
+** Non-normative comment: Edge Nodes MUST NOT act on an offline STATE message whose timestamp is
+older than the last online STATE timestamp they honored (see the
+link:#operational_behavior_edge_node_session_termination[Edge Node Session Termination] section). If
+a Host Application were to publish an online STATE message with a timestamp newer than the one in
+its registered Will Message, its own Death Certificate would be older than that online STATE message
+and Edge Nodes would ignore it. The Host Application's death would become undetectable, and Edge
+Nodes would continue publishing to a Host Application that is no longer present. This is why a Host
+Application cannot simply publish a fresh timestamp into an established session, and why obtaining a
+newer timestamp requires a new MQTT CONNECT packet.
+
+[[operational_behavior_host_application_own_state_classifying]]
+==== Classifying a Delivered STATE Message
+
+The MQTT RETAIN flag of a delivered STATE message distinguishes the value that was retained on the
+topic at the time the Host Application subscribed from a message published while the Host
+Application was already subscribed.
+
+The requirements in this section and in the
+link:#operational_behavior_host_application_own_state_restoring[Restoring the Retained STATE Value]
+section apply only while a Host Application is in the part of its MQTT session in which its own
+online STATE message is the value that should be retained on its STATE topic.
+
+* [tck-testable tck-id-operational-behavior-hid-state-window]#[yellow-background]*[tck-id-operational-behavior-hid-state-window] A
+Sparkplug Host Application MUST classify and act on STATE messages delivered on its own Host
+Application ID as required in this section only after it has published its own online STATE message
+on that MQTT Server and before it has published a Death Certificate or otherwise initiated a
+disconnect from that MQTT Server.*#
+** Non-normative comment: before the online STATE message is published there is nothing to restore,
+because publishing it is the act that establishes the correct retained value, and it will overwrite
+whatever is on the topic. After a Death Certificate has been published, an offline value on the
+topic is the correct value.
+
+[[operational_behavior_host_application_own_state_classifying_retained]]
+===== Messages Delivered with the RETAIN Flag Set
+
+* [tck-testable tck-id-operational-behavior-hid-state-retained-delivery]#[yellow-background]*[tck-id-operational-behavior-hid-state-retained-delivery] A
+Sparkplug Host Application MUST treat a STATE message delivered on its own Host Application ID with
+the MQTT RETAIN flag set to 1 as the value retained on that topic at the time it subscribed, and
+MUST NOT treat such a message as evidence that another MQTT client has published during its own
+session.*#
+** Non-normative comment: because a Host Application subscribes to its own STATE topic before
+publishing its own online STATE message, the retained value it is delivered is normally the Death
+Certificate of its own previous MQTT session, and requires no action. Relying on the RETAIN flag
+rather than on delivery order matters because the delivery of a retained message is asynchronous and
+MAY arrive after the Host Application has published its own online STATE message.
+* [tck-testable tck-id-operational-behavior-hid-state-retained-newer]#[yellow-background]*[tck-id-operational-behavior-hid-state-retained-newer] If
+the STATE message delivered on its own Host Application ID with the MQTT RETAIN flag set to 1
+carries a timestamp greater than or equal to _T_, the Sparkplug Host Application MUST immediately
+disconnect from that MQTT Server and reconnect to it, following all of the rules for Host
+Applications when establishing a connection to an MQTT Server, so that it obtains a Will Message and
+an online STATE message that both carry a timestamp newer than the retained timestamp.*#
+** Non-normative comment: a Host Application whose online STATE message is not newer than the value
+already retained on its own topic begins its session having already lost the timestamp comparison.
+Edge Nodes holding the retained timestamp will not honor its online STATE message, and its
+registered Will Message is below that timestamp, so its own Death Certificate would also be ignored.
+Reconnecting is the only way to obtain a newer timestamp, for the reason given in the
+link:#operational_behavior_host_application_own_state_will_invariant[Will Message Timestamp
+Invariant] section.
+** Non-normative comment: this condition arises when another MQTT client published on the topic
+while this Host Application was offline, and also when this Host Application's own system clock has
+moved backwards relative to its previous session. The required action is the same in both cases.
+
+[[operational_behavior_host_application_own_state_classifying_live]]
+===== Messages Delivered without the RETAIN Flag Set
+
+* [tck-testable tck-id-operational-behavior-hid-state-own-echo]#[yellow-background]*[tck-id-operational-behavior-hid-state-own-echo] A
+Sparkplug Host Application MUST treat a STATE message delivered on its own Host Application ID with
+the MQTT RETAIN flag set to 0 as the delivery of a message it published itself, and MUST take no
+action on it, if the message's client_id is its own MQTT Client ID for that MQTT Server, its bd_seq
+number is the bd_seq number of its current MQTT session with that MQTT Server, and it matches a
+STATE message that the Host Application has published in that session.*#
+** A Host Application's own online STATE message carries an 'online' value of true and a timestamp
+equal to _T_. A Host Application's own Death Certificate published immediately before a clean
+disconnect carries an 'online' value of false and the timestamp at which that disconnect is
+occurring.
+** Non-normative comment: a Host Application remains subscribed to its own STATE topic for the whole
+of its MQTT session, so a STATE message it publishes is normally delivered back to it. Neither its
+own online STATE message nor the Death Certificate it publishes immediately before a clean
+disconnect is a reason to take corrective action.
+** Non-normative comment: this requirement concerns only the two STATE messages a Host Application
+publishes itself. The Death Certificate that the MQTT Server releases as the Will Message is not
+delivered to the Host Application, because the MQTT Server releases it only when the session has
+ended and the Host Application is by then no longer connected to receive it.
+** Non-normative comment: a Host Application that uses the MQTT 5.0 'No Local' subscription option
+on its own STATE topic is never delivered its own published STATE messages at all, so this
+requirement has no effect for it. See the
+link:#operational_behavior_primary_host_application_session_establishment[Host Application Session
+Establishment] section.
+* [tck-testable tck-id-operational-behavior-hid-state-foreign-client-id]#[yellow-background]*[tck-id-operational-behavior-hid-state-foreign-client-id] A
+Sparkplug Host Application MUST treat a STATE message delivered on its own Host Application ID whose
+client_id is not its own MQTT Client ID for that MQTT Server, or whose bd_seq number is not the
+bd_seq number of its current MQTT session with that MQTT Server, as having been published by another
+MQTT client.*#
+** Non-normative comment: two running instances configured with the same Sparkplug Host Application
+ID is a common misconfiguration, and it presents exactly this way. Each instance sees STATE messages
+carrying the other's MQTT Client ID. A Host Application SHOULD report this condition, because
+corrective republishing and reconnecting between two such instances will not converge and the
+underlying cause is a configuration error rather than a hostile client.
+* [tck-testable tck-id-operational-behavior-hid-state-foreign]#[yellow-background]*[tck-id-operational-behavior-hid-state-foreign] A
+Sparkplug Host Application MUST treat any other STATE message delivered on its own Host Application
+ID with the MQTT RETAIN flag set to 0 as having been published by another MQTT client, and MUST act
+on every STATE message it has determined to have been published by another MQTT client as required
+in the link:#operational_behavior_host_application_own_state_restoring[Restoring the Retained STATE
+Value] section.*#
+** Non-normative comment: a Host Application publishes on its own STATE topic at most twice in an
+MQTT session. Its registered Will Message is released by the MQTT Server only when the session ends,
+at which point the Host Application is no longer connected to receive it. Any other live STATE
+message on its own Host Application ID therefore originated elsewhere.
+** Non-normative comment: the client_id and bd_seq values sharpen this classification but do not
+authenticate it. An MQTT client able to publish on the topic can copy both from the retained value.
+A STATE message carrying this Host Application's own client_id and current bd_seq number, with an
+'online' value of false and the timestamp of its own session, remains indistinguishable in content
+from its own registered Will Message.
+** Non-normative comment: the RETAIN flag identifies when a message was published relative to the
+Host Application's own subscription. It does not identify the publisher, and it is not an
+authentication mechanism. See the link:#security_implementation_notes_acls[Access Control Lists]
+section.
+
+[[operational_behavior_host_application_own_state_restoring]]
+==== Restoring the Retained STATE Value
+
+Two corrective actions are available. Which one is required depends on whether the Host
+Application's own timestamp _T_ is still the greatest timestamp seen on its own Host Application ID,
+because that determines whether _T_ is still sufficient for Edge Nodes to honor an online STATE
+message.
+
+* [tck-testable tck-id-operational-behavior-hid-state-restore-republish]#[yellow-background]*[tck-id-operational-behavior-hid-state-restore-republish] If
+the timestamp of the offending STATE message is less than _T_, or the offending STATE message
+carries a payload that is zero length, is not valid JSON UTF-8 data, or does not contain all of the
+'online', 'timestamp', 'bd_seq', and 'client_id' keys, the Sparkplug Host Application MUST
+immediately republish its online STATE message on the same MQTT Server, with an 'online' value of
+true and a timestamp equal to _T_, with a QoS of 1 and the retain flag set to true. It MUST NOT
+disconnect.*#
+** Non-normative comment: a zero length payload published with the retain flag set removes the
+retained message from the topic on the MQTT Server, leaving the Host Application's STATE topic with
+no retained value at all. An Edge Node that connects afterwards finds nothing to evaluate and cannot
+determine that its Primary Host Application is online. Republishing at _T_ restores the retained
+value, and no comparison against the offending message is possible or necessary because it carries
+no timestamp.
+** Non-normative comment: republishing at _T_ restores the retained value and preserves the Will
+Message timestamp invariant, because the registered Will Message timestamp is already equal to _T_.
+A new MQTT CONNECT packet is not required and would cause avoidable disruption.
+** Non-normative comment: an offending STATE message with an 'online' value of false and a timestamp
+older than _T_ is ignored by Edge Nodes that are already in a session with this Host Application,
+but it displaces the retained value on the topic. An Edge Node that connects afterwards has no
+previous timestamp for this Host Application and so honors whatever it finds retained, which would
+leave it waiting for a Primary Host Application that is in fact online. Restoring the retained value
+is what prevents that.
+* [tck-testable tck-id-operational-behavior-hid-state-restore-reconnect]#[yellow-background]*[tck-id-operational-behavior-hid-state-restore-reconnect] If
+the timestamp of the offending STATE message is greater than or equal to _T_, the Sparkplug Host
+Application MUST immediately disconnect from that MQTT Server and reconnect to it, following all of
+the rules for Host Applications when establishing a connection to an MQTT Server, so that it obtains
+a new Will Message and a new online STATE message that both carry a timestamp newer than that of the
+offending STATE message.*#
+** Republishing at _T_ is not sufficient in this case. Where the offending timestamp is greater than
+_T_, an Edge Node that has honored the offending STATE message will not honor an online STATE
+message whose timestamp is older than it. Where the offending timestamp is equal to _T_, an online
+STATE message republished at _T_ would neither win nor lose against it, so which of the two an Edge
+Node ends up honoring would depend on the order in which they arrive, and a Host Application that
+only ever republishes at _T_ could never establish precedence over a client that continues to
+publish at _T_. In both cases a timestamp strictly newer than the offending message is required, and
+the Will Message Timestamp Invariant means such a timestamp can only be obtained through a new MQTT
+CONNECT packet.
+** Non-normative comment: an offending STATE message with an 'online' value of true and a timestamp
+newer than _T_ causes no immediately visible change, because Edge Nodes already consider this Host
+Application to be online. It is nonetheless the most damaging case, because it raises the last
+online STATE timestamp that Edge Nodes hold above the timestamp in this Host Application's
+registered Will Message, which disarms the Host Application's own Death Certificate. Reconnecting
+restores the invariant.
+* [tck-testable tck-id-operational-behavior-hid-state-restore-scope]#[yellow-background]*[tck-id-operational-behavior-hid-state-restore-scope] A
+Sparkplug Host Application MUST apply the corrective action only to the MQTT Server on which the
+offending STATE message was delivered, and MUST NOT disconnect from, or republish its STATE message
+to, any other MQTT Server as a result.*#
+** Non-normative comment: a Primary Host Application maintains an MQTT session, and therefore a
+separate retained STATE value, with every MQTT Server in the infrastructure. A STATE message
+published by another client on one MQTT Server says nothing about the state of any other MQTT
+Server, and disconnecting from a healthy MQTT Server would strand the Edge Nodes connected to it.
+* [tck-testable tck-id-operational-behavior-hid-state-restore-backoff]#[yellow-background]*[tck-id-operational-behavior-hid-state-restore-backoff] A
+Sparkplug Host Application SHOULD limit the rate at which it performs these corrective actions on
+any single MQTT Server, and SHOULD escalate from republishing to reconnecting if republishing does
+not resolve the condition.*#
+** Non-normative comment: each corrective action is triggered by an inbound message, so an MQTT
+client that repeatedly publishes on a Host Application's STATE topic can otherwise drive an
+unbounded sequence of reconnects. Rate limiting bounds that. It does not prevent the underlying
+condition; restricting publish access to the STATE topic does, as described in the
+link:#security_implementation_notes_acls[Access Control Lists] section.
+** Non-normative comment: reconnecting is considerably more disruptive than republishing. Ending an
+MQTT session always announces the Host Application as offline, either through the Death Certificate
+it publishes before a clean disconnect or through the Will Message the MQTT Server releases, so
+every Edge Node configured with it as their Primary Host Application will terminate its session and
+re-establish once the new online STATE message is published. This is unavoidable, because a new Will
+Message can only be registered in a new MQTT CONNECT packet. It is the reason the republish action
+is required wherever it is sufficient.
+
+[[operational_behavior_host_application_own_state_limits]]
+==== Limits of Retained STATE Restoration
+
+Non-normative comment: these requirements make a connected Host Application detect displacement of
+its own retained STATE value and restore it within a bounded time, without ever violating the Will
+Message Timestamp Invariant. They do not make the retained value correct at all times, and cannot.
+There is always an interval between the offending publish and the corrective publish during which
+the retained value is wrong. A client that publishes repeatedly can keep the retained value wrong
+for much of the time. Most importantly, while a Host Application is genuinely offline it cannot
+correct anything at all, so an MQTT client that publishes an online STATE message with a newer
+timestamp on the Host Application's topic while that Host Application is offline will leave Edge
+Nodes believing a Primary Host Application is online when it is not. No Host Application behavior
+can address that case. It is prevented by restricting publish access to the STATE topic.
 
 [[operational_behavior_edge_node_session_establishment]]
 === Edge Node Session Establishment
@@ -221,6 +479,55 @@ value is greater than or equal to the previous STATE message timestamp value in 
 payload before considering the Primary Host Application to be online and active. If no previous
 STATE message timestamp value has been received by this Edge Node it MUST consider the incoming
 STATE message to be the latest/valid.*#
+** [tck-testable tck-id-message-flow-edge-node-birth-publish-phid-wait-retained]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-phid-wait-retained] A
+STATE message delivered to an Edge Node with the MQTT RETAIN flag set to 1 is the value retained on
+the Primary Host Application's STATE topic at the time the Edge Node subscribed, and the Edge Node
+MUST evaluate it as the current state of that Primary Host Application. A STATE message delivered
+with the MQTT RETAIN flag set to 0 is a live publish, and the Edge Node MUST evaluate it as a change
+to that state.*#
+*** Non-normative comment: this is what distinguishes the state an Edge Node finds when it
+subscribes from a subsequent change to that state. It is the case in which no previous STATE message
+timestamp has been received, referred to in the requirement above.
+*** Non-normative comment: the RETAIN flag does not indicate which client published a STATE message.
+An Edge Node cannot use it to distinguish a Death Certificate released by the MQTT Server on behalf
+of a Primary Host Application from an identical message published by another client. See the
+link:#security_implementation_notes_acls[Access Control Lists] section.
+** [tck-testable tck-id-message-flow-edge-node-birth-publish-phid-wait-absent]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-phid-wait-absent] If
+no STATE message is retained on the configured Primary Host Application's STATE topic, an Edge Node
+that is configured to wait for that Primary Host Application MUST NOT consider it to be online, and
+MUST NOT publish its NBIRTH and DBIRTH messages, until it is delivered a STATE message denoting that
+Primary Host Application to be online.*#
+*** An Edge Node SHOULD make this condition visible, because it is not distinguishable by the Edge
+Node from a Primary Host Application that has never been started.
+*** Non-normative comment: an MQTT client that publishes a zero length payload with the retain flag
+set to the Primary Host Application's STATE topic removes the retained value, which leaves every
+Edge Node that connects afterwards waiting indefinitely. The Primary Host Application detects and
+repairs this while it is connected, as required in the
+link:#operational_behavior_host_application_own_state[Host Application Handling of STATE Messages on
+its Own Host Application ID] section, but it cannot do so while it is offline. See the
+link:#security_implementation_notes_acls[Access Control Lists] section.
+** [tck-testable tck-id-message-flow-edge-node-birth-publish-phid-wait-malformed]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-phid-wait-malformed] An
+Edge Node MUST ignore a STATE message delivered on the configured Primary Host Application's STATE
+topic whose payload is zero length, is not valid JSON UTF-8 data, or does not contain all of the
+'online', 'timestamp', 'bd_seq', and 'client_id' keys. It MUST NOT change its view of that Primary
+Host Application's state as a result of such a message, and MUST NOT store its timestamp or bd_seq
+number for later comparison.*#
+*** Non-normative comment: retaining the last valid state is the safer behavior. Treating an
+unparseable payload as an offline indication would allow any client able to publish on the topic to
+strand every Edge Node with a payload that does not even have to be well formed.
+** [tck-testable tck-id-message-flow-edge-node-birth-publish-phid-wait-bdseq]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-phid-wait-bdseq] An
+Edge Node that has honored an online STATE message from its configured Primary Host Application MUST
+store the bd_seq number and client_id from that message, and MUST treat a subsequent offline STATE
+message as terminating that Primary Host Application session only if its bd_seq number and client_id
+match the stored values.*#
+*** Non-normative comment: this is the same correlation an Edge Node performs between an NDEATH and
+the NBIRTH it terminates, applied to a Sparkplug Host Application. It identifies the session an
+offline STATE message refers to directly, rather than inferring it from timestamp ordering alone.
+*** Non-normative comment: the timestamp comparison is still required and is not replaced by this.
+An Edge Node that has not previously honored an online STATE message from a Primary Host Application
+has no stored bd_seq number to compare against, so the bd_seq number is only meaningful relative to
+a session the Edge Node has already observed, whereas the timestamp gives an ordering an Edge Node
+can evaluate on a value it is seeing for the first time.
 * [tck-testable tck-id-message-flow-edge-node-birth-publish-nbirth-topic]#[yellow-background]*[tck-id-message-flow-edge-node-birth-publish-nbirth-topic] The
 Edge Node's NBIRTH MQTT topic MUST be of the form
 '[topic_prefix/]spCv4.0/NBIRTH/edge_node_id' where the optional topic_prefix is the Sparkplug Topic
@@ -1157,10 +1464,13 @@ a Sparkplug Host Application sends its MQTT CONNECT packet, it MUST include a Wi
 MQTT Will Message's topic MUST be of the form 'spCv4.0/STATE/sparkplug_host_id' where host_id is the
 unique identifier of the Sparkplug Host Application*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-will-payload]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-will-payload] The
-Death Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where one key
-MUST be 'online' and it's value is a boolean 'false'. The other key MUST be 'timestamp' and the
-value MUST be the same value that was used for the timestamp in its own prior MQTT CONNECT packet
-Will Message payload.*#
+Death Certificate Payload MUST be JSON UTF-8 data. It MUST include four key/value pairs. One key
+MUST be 'online' and it's value is a boolean 'false'. One key MUST be 'timestamp' and the value MUST
+be the same value that was used for the timestamp in its own prior MQTT CONNECT packet Will Message
+payload. One key MUST be 'bd_seq' and the value MUST be as defined in the
+link:#payloads_c_state_bd_seq[STATE bd_seq Number] section. One key MUST be 'client_id' and the
+value MUST be the MQTT Client ID of the MQTT session in which the message was published, as defined
+in the link:#payloads_c_state_client_id[STATE client_id] section.*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-will-qos]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-will-qos] The
 MQTT Will Message's MQTT QoS MUST be 1 (at least once).*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-will-retained]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-will-retained] The
@@ -1176,10 +1486,13 @@ after successfully connecting to the MQTT Server.*#
 Host Application's Birth topic MUST be of the form 'spCv4.0/STATE/sparkplug_host_id' where host_id
 is the unique identifier of the Sparkplug Host Application*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-birth-payload]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-birth-payload] The
-Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where one key
-MUST be 'online' and it's value is a boolean 'true'. The other key MUST be 'timestamp' and the value
-MUST match the timestamp value that was used in the immediately prior MQTT CONNECT packet Will
-Message payload.*#
+Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include four key/value pairs. One key
+MUST be 'online' and it's value is a boolean 'true'. One key MUST be 'timestamp' and the value MUST
+match the timestamp value that was used in the immediately prior MQTT CONNECT packet Will Message
+payload. One key MUST be 'bd_seq' and the value MUST be as defined in the
+link:#payloads_c_state_bd_seq[STATE bd_seq Number] section. One key MUST be 'client_id' and the
+value MUST be the MQTT Client ID of the MQTT session in which the message was published, as defined
+in the link:#payloads_c_state_client_id[STATE client_id] section.*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-birth-qos]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-birth-qos] The
 Host Application's Birth MQTT QoS MUST be 1 (at least once).*#
 * [tck-testable tck-id-operational-behavior-host-application-connect-birth-retained]#[yellow-background]*[tck-id-operational-behavior-host-application-connect-birth-retained] The
@@ -1206,9 +1519,12 @@ Sparkplug Host Application's Death topic MUST be of the form 'spCv4.0/STATE/spar
 host_id is the unique identifier of the Sparkplug Host Application.*#
 * [tck-testable tck-id-operational-behavior-host-application-death-payload]#[yellow-background]*[tck-id-operational-behavior-host-application-death-payload] The
 Death Certificate Payload registered as the MQTT Will Message in the MQTT CONNECT packet MUST be
-JSON UTF-8 data. It MUST include two key/value pairs where one key MUST be 'online' and it's value
-is a boolean 'false'. The other key MUST be 'timestamp' and the value MUST be a numeric value
-representing the current UTC time in nanoseconds since Epoch.*#
+JSON UTF-8 data. It MUST include four key/value pairs. One key MUST be 'online' and it's value is a
+boolean 'false'. One key MUST be 'timestamp' and the value MUST be a numeric value representing the
+current UTC time in nanoseconds since Epoch. One key MUST be 'bd_seq' and the value MUST be as
+defined in the link:#payloads_c_state_bd_seq[STATE bd_seq Number] section. One key MUST be
+'client_id' and the value MUST be the MQTT Client ID of the MQTT session in which the message was
+published, as defined in the link:#payloads_c_state_client_id[STATE client_id] section.*#
 * [tck-testable tck-id-operational-behavior-host-application-death-qos]#[yellow-background]*[tck-id-operational-behavior-host-application-death-qos] The
 Sparkplug Host Application's Death MQTT QoS MUST be 1 (at least once).*#
 * [tck-testable tck-id-operational-behavior-host-application-death-retained]#[yellow-background]*[tck-id-operational-behavior-host-application-death-retained] The

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -460,8 +460,11 @@ DREBIRTH, DDATA, DRESP, and DDEATH messages all carry a bd_seq number.
 because the MQTT Server cannot know the Edge Node's current position in either stream when it releases
 the Will Message. It does carry a bd_seq number, because that value is fixed for the whole session and
 is therefore known when the Will Message is registered in the MQTT CONNECT packet.
-***** Non-normative comment: messages published by Sparkplug Host Applications rather than by Edge
-Nodes (NCMD, DCMD, REBIRTH, and STATE) do not carry a bd_seq number.
+***** Non-normative comment: the NCMD, DCMD, and REBIRTH messages published by Sparkplug Host
+Applications do not carry a bd_seq number. A STATE message does carry one, scoping it to the MQTT
+session of the Sparkplug Host Application that published it, but it is a bd_seq number maintained by
+that Host Application and is unrelated to the bd_seq number of any Edge Node. See the
+link:#payloads_c_state_bd_seq[STATE bd_seq Number] section.
 **** [tck-testable tck-id-payloads-bd-sequence-num-req-nbirth]#[yellow-background]*[tck-id-payloads-bd-sequence-num-req-nbirth] Every
 birth/death sequence number included in the payload from an Edge Node MUST always be between 0 and
 18446744073709551615 (inclusive).*#
@@ -2402,9 +2405,13 @@ Sparkplug Host Application MUST set the the MQTT Will QoS to 1 in the MQTT CONNE
 * [tck-testable tck-id-payloads-state-will-message-retain]#[yellow-background]*[tck-id-payloads-state-will-message-retain] The
 Sparkplug Host Application MUST set the Will Retained flag to true in the MQTT CONNECT packet.*#
 * [tck-testable tck-id-payloads-state-will-message-payload]#[yellow-background]*[tck-id-payloads-state-will-message-payload] The
-Death Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where one key
-MUST be 'online' and it's value is a boolean 'false'. The other key MUST be 'timestamp' and the
-value MUST be a numeric value representing the current UTC time in nanoseconds since Epoch.*#
+Death Certificate Payload MUST be JSON UTF-8 data. It MUST include four key/value pairs. One key
+MUST be 'online' and it's value is a boolean 'false'. One key MUST be 'timestamp' and the value MUST
+be a numeric value representing the current UTC time in nanoseconds since Epoch. One key MUST be
+'bd_seq' and the value MUST be a numeric value as defined in the link:#payloads_c_state_bd_seq[STATE
+bd_seq Number] section. One key MUST be 'client_id' and the value MUST be the UTF-8 MQTT Client ID
+that the Sparkplug Host Application used in the MQTT CONNECT packet that registered this Will
+Message.*#
 * [tck-testable tck-id-payloads-state-subscribe]#[yellow-background]*[tck-id-payloads-state-subscribe] After
 establishing an MQTT connection, the Sparkplug Host Application MUST subscribe on it's own
 'spCv4.0/STATE/[sparkplug_host_id]' topic.*#
@@ -2420,10 +2427,97 @@ retain flag set to true.*#
 ** The [sparkplug_host_id] should be replaced with the Sparkplug Host Application's ID. This can be
 any UTF-8 string.
 * [tck-testable tck-id-payloads-state-birth-payload]#[yellow-background]*[tck-id-payloads-state-birth-payload] The
-Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include two key/value pairs where one key
-MUST be 'online' and it's value is a boolean 'true'. The other key MUST be 'timestamp' and the value
+Birth Certificate Payload MUST be JSON UTF-8 data. It MUST include four key/value pairs. One key
+MUST be 'online' and it's value is a boolean 'true'. One key MUST be 'timestamp' and the value
 MUST match the timestamp value that was used in the immediately prior MQTT CONNECT packet Will
-Message payload.*#
+Message payload. One key MUST be 'bd_seq' and the value MUST match the bd_seq value that was used in
+that same Will Message payload. One key MUST be 'client_id' and the value MUST be the UTF-8 MQTT
+Client ID that the Sparkplug Host Application used in that same MQTT CONNECT packet.*#
+
+[[payloads_c_state_bd_seq]]
+===== STATE bd_seq Number
+
+The bd_seq number in a STATE payload scopes that STATE message to a single MQTT session of a
+Sparkplug Host Application, in the same way that the bd_seq number in an Edge Node's payload scopes
+a message to a single MQTT session of that Edge Node. It allows a Sparkplug Host Application's Death
+Certificate to be matched to the Birth Certificate of the session it terminates.
+
+* [tck-testable tck-id-payloads-state-bdseq-included]#[yellow-background]*[tck-id-payloads-state-bdseq-included] A
+bd_seq number MUST be included in every STATE message published by or on behalf of a Sparkplug Host
+Application, including the Death Certificate registered as the MQTT Will Message.*#
+* [tck-testable tck-id-payloads-state-bdseq-range]#[yellow-background]*[tck-id-payloads-state-bdseq-range] The
+bd_seq number in a STATE payload MUST always be between 0 and 18446744073709551615 (inclusive).*#
+* [tck-testable tck-id-payloads-state-bdseq-session-constant]#[yellow-background]*[tck-id-payloads-state-bdseq-session-constant] Every
+STATE message a Sparkplug Host Application publishes within a single MQTT session MUST carry the
+same bd_seq number, and that value MUST be the one registered in the Will Message payload of that
+session's MQTT CONNECT packet.*#
+* [tck-testable tck-id-payloads-state-bdseq-increment]#[yellow-background]*[tck-id-payloads-state-bdseq-increment] The
+bd_seq number MUST start at zero and MUST increment by one on every new MQTT CONNECT packet the
+Sparkplug Host Application sends to a given MQTT Server, until a value of 18446744073709551615 (max
+value of a UINT64) is reached. At that point the bd_seq number of the following MQTT CONNECT packet
+MUST be zero.*#
+** Non-normative comment: these are the same rules that apply to an Edge Node's bd_seq number. As
+with an Edge Node, the bd_seq number is not incremented from message to message within a session.
+* [tck-testable tck-id-payloads-state-bdseq-per-server]#[yellow-background]*[tck-id-payloads-state-bdseq-per-server] A
+Sparkplug Host Application that maintains MQTT sessions with more than one MQTT Server MUST maintain
+an independent bd_seq number for each MQTT Server.*#
+** Non-normative comment: a Sparkplug Host Application establishes and loses sessions with each MQTT
+Server independently, so a single shared counter would advance for reasons unrelated to the server a
+consuming Edge Node is connected to.
+
+[[payloads_c_state_client_id]]
+===== STATE client_id
+
+The client_id in a STATE payload is the MQTT Client ID of the MQTT client that published the
+message.
+
+* [tck-testable tck-id-payloads-state-client-id-included]#[yellow-background]*[tck-id-payloads-state-client-id-included] A
+client_id MUST be included in every STATE message published by or on behalf of a Sparkplug Host
+Application, including the Death Certificate registered as the MQTT Will Message.*#
+* [tck-testable tck-id-payloads-state-client-id-value]#[yellow-background]*[tck-id-payloads-state-client-id-value] The
+client_id value MUST be the UTF-8 MQTT Client ID used in the MQTT CONNECT packet of the MQTT session
+in which the STATE message was published, or, for a Death Certificate registered as a Will Message,
+of the MQTT session in which that Will Message was registered.*#
+** Non-normative comment: a Sparkplug Host Application ID identifies a logical Host Application,
+whereas the MQTT Client ID identifies the MQTT client instance that published a given STATE message.
+Including it makes it possible to see which client instance produced a STATE message.
+** Non-normative comment: the most common practical use of this field is detecting a
+misconfiguration in which two running instances are configured with the same Sparkplug Host
+Application ID. Each instance subscribes to its own STATE topic, so each will be delivered STATE
+messages carrying the other's MQTT Client ID and can report the conflict. Without this field the two
+instances repeatedly displace each other's retained STATE value and the cause is not visible in the
+messages themselves.
+** Non-normative comment: the client_id is not an authentication mechanism. Any MQTT client able to
+publish on the topic can place any value in this field, including the Sparkplug Host Application's
+own MQTT Client ID. See the link:#security_implementation_notes_acls[Access Control Lists] section.
+
+The following is a representation of a Sparkplug Host Application Birth Certificate published on the
+topic:
+
+----
+spCv4.0/STATE/my_host_application
+----
+
+----
+{
+        "online": true,
+        "timestamp": 1486144502122,
+        "bd_seq": 12,
+        "client_id": "my_host_application_client_1"
+}
+----
+
+The corresponding Death Certificate registered as the MQTT Will Message in the same MQTT CONNECT
+packet carries the same timestamp, the same bd_seq number, and the same client_id:
+
+----
+{
+        "online": false,
+        "timestamp": 1486144502122,
+        "bd_seq": 12,
+        "client_id": "my_host_application_client_1"
+}
+----
 
 [[payloads_c_compression]]
 ==== Compression

--- a/specification/src/main/asciidoc/chapters/Sparkplug_7_Security.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_7_Security.adoc
@@ -120,3 +120,52 @@ compromised, the potential harm that could be done by a malicious client would b
 For example, a client would not be able to appear to be as some other client. Subscribing on # would
 not be allowed so the full scope of a Sparkplug topic namespace could not be realized by the
 malicious client with the compromised credentials.
+
+Note that in every example above the Edge Node is granted subscribe access to the Primary Host
+Application's STATE topic and is never granted publish access to it. This is deliberate and it is
+the single most important ACL in a Sparkplug infrastructure.
+
+* [tck-testable tck-id-security-acl-host-state-publish]#[yellow-background]*[tck-id-security-acl-host-state-publish] When
+the MQTT Server supports Access Control Lists, publish access to a Sparkplug Host Application's
+STATE topic SHOULD be granted only to that Sparkplug Host Application.*#
+
+The STATE topic is the mechanism by which Edge Nodes decide whether their Primary Host Application
+is online, and it is published with the MQTT retain flag set, so its value persists until it is
+overwritten. Any MQTT client permitted to publish on a Host Application's STATE topic can therefore
+declare that Host Application offline and cause every Edge Node configured with it as their Primary
+Host Application to terminate its session and walk to another MQTT Server, or declare it online
+while it is in fact absent and cause Edge Nodes to keep publishing to a Host Application that is not
+there.
+
+A Host Application detects and repairs displacement of its own retained STATE value while it is
+connected, as required in the link:#operational_behavior_host_application_own_state[Host Application
+Handling of STATE Messages on its Own Host Application ID] section. That mechanism is recovery, not
+prevention. It cannot close the interval between a spurious publish and the repair, and it cannot
+act at all while the Host Application is offline, because a Host Application that is not connected
+cannot correct its own retained value. An ACL restricting publish access to the STATE topic is the
+only measure that prevents the condition rather than recovering from it.
+
+Note also that an Edge Node cannot distinguish a Death Certificate released by the MQTT Server on
+behalf of a genuinely disconnected Host Application from an identical message published by another
+client. Both are delivered to an established subscription with the MQTT RETAIN flag set to 0, and a
+Host Application's Will Message payload and its online STATE message payload carry the same
+timestamp, bd_seq number, and client_id, so a spurious offline STATE message that reproduces those
+values is indistinguishable in content from the Host Application's own registered Will Message. The
+bd_seq number and client_id in a STATE payload make a careless or accidental publisher identifiable,
+and in particular make a misconfiguration in which two instances share one Sparkplug Host
+Application ID visible, but they are copied from a retained value that any subscriber can read and
+so do not resist a deliberate forgery. No Edge Node behavior can resolve this, which is a further
+reason to control publish access to the topic.
+
+A zero length payload published to a STATE topic with the retain flag set removes the retained
+message from that topic rather than replacing it. This deserves specific attention when configuring
+ACLs, because it leaves the topic with no retained value and therefore nothing for a newly
+connecting Edge Node to evaluate, without publishing any content that a reviewer of message payloads
+would notice.
+
+Finally, note that topic ACLs do not address every way a Host Application's STATE topic can be
+displaced. If another MQTT client is able to connect using the same MQTT Client ID as a Sparkplug
+Host Application, the MQTT Server will terminate that Host Application's session and release its
+Will Message, and the Host Application cannot correct anything while it is disconnected. Sparkplug
+Host Application and Edge Node credentials SHOULD therefore be scoped so that no two MQTT clients
+are able to connect using the same MQTT Client ID.


### PR DESCRIPTION
  Closes #547. Follow-on to #619.

  The fix #547 asked for was already applied in `ed32df1` — a Host Application receiving a STATE
  message on its own Host ID with a *newer* timestamp disconnects and reconnects, rather than
  republishing with the same timestamp. This PR closes the gaps that fix left behind, and adds the
  `bd_seq` and `client_id` fields to the STATE payload.

  ### The gap

  The Host and the Edge Node used different comparisons. An Edge Node acts on an offline STATE whose
  timestamp is `>=` the last online one; the Host only reacted to one strictly *newer* than its own. So
  `{"online": false, "timestamp": T}` with the Host's exact `T` — readable by anyone, since STATE is
  retained — makes every Edge Node walk away while the Host never notices. Two more variants were also
  uncovered: an offline STATE with an *older* timestamp poisons the retained value and blocks every Edge
  Node that connects afterwards, and a zero-length retained publish deletes the retained value
  entirely, leaving new Edge Nodes waiting indefinitely with nothing in the spec to detect it.

  ### New section: Host Application Handling of STATE Messages on its Own Host Application ID (Ch. 5)

  **The Will Message Timestamp Invariant** (`hid-state-will-invariant`) — the registered Will timestamp
  MUST be ≥ the most recent online STATE timestamp published on that server. Previously implicit. It is
  what forbids "republish with a fresh timestamp": doing so would leave the Will older than the online
  STATE, and Edge Nodes ignore a death older than the last online they honored — so the Host's death
  would become undetectable. A newer timestamp requires a new CONNECT, because a Will payload is frozen
  at CONNECT.

  **Classification by the MQTT RETAIN flag.** RETAIN=1 on delivery means the value retained at subscribe
  time; RETAIN=0 means a live publish during the session. This removes a race — the Host subscribes to
  its own STATE topic before publishing its birth, so it always receives the prior session's death, and
  that delivery is asynchronous and can land after the birth publish. Statements: `hid-state-window`
  (the mechanism applies only after publishing its own online STATE and before initiating a disconnect),
  `hid-state-retained-delivery`, `hid-state-retained-newer` (a retained timestamp `>= T` means the
  session was born already losing the comparison, from a planted value or a backward clock jump —
  reconnect), `hid-state-own-echo`, `hid-state-foreign-client-id`, `hid-state-foreign`.

  **Two-tier restoration.** `hid-state-restore-republish` — where the offending timestamp is `< T`, or
  the payload is zero-length or malformed, republish `{true, T}` retained and MUST NOT disconnect; this
  restores the retained value and preserves the Will invariant. `hid-state-restore-reconnect` — where it
  is `>= T`, reconnect, because republishing at `T` either loses the comparison or merely ties, and a
  Host that only ever republishes at `T` can never gain precedence over a client that keeps publishing
  at `T`. Plus `hid-state-restore-scope` (act only on the MQTT Server that delivered the message; a
  Primary Host holds a separate retained value per server) and `hid-state-restore-backoff`.

  **Limits** — non-normative. This yields bounded convergence, not permanent correctness. A forged
  online STATE published while the Host is *offline* cannot be corrected by any Host behavior.

  ### STATE payload: bd_seq and client_id

  `payloads_c_state_bd_seq` (5 statements) mirrors the Edge Node rules — required in every STATE
  including the Will, constant within a session, equal to the CONNECT Will value, incrementing per
  CONNECT with UINT64 rollover — plus an independent counter per MQTT Server, since sessions are
  established and lost per server. `payloads_c_state_client_id` (2 statements) carries the MQTT Client ID
  of the publishing session.

  This makes a Host's Death Certificate correlatable to the Birth Certificate of the session it
  terminates (`phid-wait-bdseq`), the same way an Edge Node correlates NDEATH to NBIRTH. It also makes
  the common misconfiguration of two instances sharing one Sparkplug Host Application ID visible and
  reportable — previously invisible, and it never converges under republish/reconnect.

  The timestamp comparison is *not* replaced. A cold-starting Edge Node has no stored `bd_seq`, so
  `bd_seq` is only meaningful relative to a session already observed; the timestamp remains the absolute
  The fix #547 asked for was already applied in `ed32df1` — a Host Application receiving a STATE
  message on its own Host ID with a *newer* timestamp disconnects and reconnects, rather than
  republishing with the same timestamp. This PR closes the gaps that fix left behind, and adds the
  `bd_seq` and `client_id` fields to the STATE payload.

  ### The gap

  The Host and the Edge Node used different comparisons. An Edge Node acts on an offline STATE whose
  timestamp is `>=` the last online one; the Host only reacted to one strictly *newer* than its own. So
  `{"online": false, "timestamp": T}` with the Host's exact `T` — readable by anyone, since STATE is
  retained — makes every Edge Node walk away while the Host never notices. Two more variants were also
  uncovered: an offline STATE with an *older* timestamp poisons the retained value and blocks every Edge
  Node that connects afterwards, and a zero-length retained publish deletes the retained value
  entirely, leaving new Edge Nodes waiting indefinitely with nothing in the spec to detect it.

  ### New section: Host Application Handling of STATE Messages on its Own Host Application ID (Ch. 5)

  **The Will Message Timestamp Invariant** (`hid-state-will-invariant`) — the registered Will timestamp
  MUST be ≥ the most recent online STATE timestamp published on that server. Previously implicit. It is
  what forbids "republish with a fresh timestamp": doing so would leave the Will older than the online
  STATE, and Edge Nodes ignore a death older than the last online they honored — so the Host's death
  would become undetectable. A newer timestamp requires a new CONNECT, because a Will payload is frozen
  at CONNECT.

  **Classification by the MQTT RETAIN flag.** RETAIN=1 on delivery means the value retained at subscribe
  time; RETAIN=0 means a live publish during the session. This removes a race — the Host subscribes to
  its own STATE topic before publishing its birth, so it always receives the prior session's death, and
  that delivery is asynchronous and can land after the birth publish. Statements: `hid-state-window`
  (the mechanism applies only after publishing its own online STATE and before initiating a disconnect),
  `hid-state-retained-delivery`, `hid-state-retained-newer` (a retained timestamp `>= T` means the
  session was born already losing the comparison, from a planted value or a backward clock jump —
  reconnect), `hid-state-own-echo`, `hid-state-foreign-client-id`, `hid-state-foreign`.

  **Two-tier restoration.** `hid-state-restore-republish` — where the offending timestamp is `< T`, or
  the payload is zero-length or malformed, republish `{true, T}` retained and MUST NOT disconnect; this
  restores the retained value and preserves the Will invariant. `hid-state-restore-reconnect` — where it
  is `>= T`, reconnect, because republishing at `T` either loses the comparison or merely ties, and a
  Host that only ever republishes at `T` can never gain precedence over a client that keeps publishing
  at `T`. Plus `hid-state-restore-scope` (act only on the MQTT Server that delivered the message; a
  Primary Host holds a separate retained value per server) and `hid-state-restore-backoff`.

  **Limits** — non-normative. This yields bounded convergence, not permanent correctness. A forged
  online STATE published while the Host is *offline* cannot be corrected by any Host behavior.

  ### STATE payload: bd_seq and client_id

  `payloads_c_state_bd_seq` (5 statements) mirrors the Edge Node rules — required in every STATE
  including the Will, constant within a session, equal to the CONNECT Will value, incrementing per
  CONNECT with UINT64 rollover — plus an independent counter per MQTT Server, since sessions are
  established and lost per server. `payloads_c_state_client_id` (2 statements) carries the MQTT Client ID
  of the publishing session.

  This makes a Host's Death Certificate correlatable to the Birth Certificate of the session it
  terminates (`phid-wait-bdseq`), the same way an Edge Node correlates NDEATH to NBIRTH. It also makes
  the common misconfiguration of two instances sharing one Sparkplug Host Application ID visible and
  reportable — previously invisible, and it never converges under republish/reconnect.

  The timestamp comparison is *not* replaced. A cold-starting Edge Node has no stored `bd_seq`, so
  `bd_seq` is only meaningful relative to a session already observed; the timestamp remains the absolute
  ordering. Stated explicitly so it isn't later assumed otherwise.

  All eight STATE payload statements across Ch. 4/5/6 went from two keys to four. Added a worked example
  showing a Birth Certificate and its matching Will.

  ### Edge Node STATE handling (Ch. 5)

  `phid-wait-retained` (RETAIN=1 is the state found at subscribe, RETAIN=0 is a change to it —
  previously the spec relied on "no previous timestamp received" as a proxy), `phid-wait-absent` (no
  retained STATE means not online; SHOULD be surfaced, since it is indistinguishable from a Host that
  never started), `phid-wait-malformed` (ignore, preserving last valid state — treating an unparseable
  payload as offline would let anyone strand every Edge Node with a payload that need not even be well
  formed), `phid-wait-bdseq`.

  ### MQTT subscription options (Ch. 5)

  `phid-sparkplug-subscription-retain-options` — an MQTT 5.0 Host MUST use Retain As Published = 0 and
  Retain Handling = 0 on its own STATE topic and MUST NOT use a Shared Subscription. With RAP=1 every
  delivered STATE would arrive with RETAIN=1 and the discriminator inverts; Retain Handling=2 and shared
  subscriptions suppress retained delivery entirely. `phid-sparkplug-subscription-no-local` — 'No Local'
  MAY be 0 or 1; both are conformant and externally indistinguishable, but with NL=1 the Host is never
  delivered its own STATE messages, so the echo requirement has no effect for it.

  ### Security (Ch. 7)

  `security-acl-host-state-publish` — publish access to a Host Application's STATE topic SHOULD be
  granted only to that Host Application. The Ch. 5 mechanism is recovery, not prevention: it cannot
  close the interval between a spurious publish and the repair, and cannot act while the Host is
  offline. Also documents that a forged offline STATE reproducing the Host's timestamp, `bd_seq`, and
  `client_id` is indistinguishable in content from the Host's own Will — so no Edge Node behavior can
  resolve it; that a zero-length retained publish *deletes* the retained value rather than replacing it,
  which warrants attention when reviewing ACLs; and that same-Client-ID takeover defeats topic ACLs, so
  credentials SHOULD be scoped to prevent it.