### PR TITLE
[#232] Modified Sparkplug to use nanosecond granularity for timestamps

### DIFF
--- a/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_5_Operational_Behavior.adoc
@@ -43,12 +43,45 @@ connect to the next available MQTT Server where STATE for the Primary Host Appli
 [[operational_behavior_timestamps]]
 === Timestamps in Sparkplug
 
-An important aspect of Sparkplug is its use of time. All timestamps must be in Coordinated
-Universal Time (UTC). In order to ensure this is the case, all Sparkplug Edge Nodes and Sparkplug
-Host Applications must have an accurate mechanism for ensuring their clocks remain accurate. This is
-typically left to the system operating system using technologies such as Network Time Protocol
-(NTP). Regardless of the mechanism used, ensuring all timestamps are accurate and in UTC is
-critical to Sparkplug operations.
+An important aspect of Sparkplug is its use of time. All timestamps are in Coordinated Universal
+Time (UTC), as required in the link:#payloads_c_payload_header[Header] section. In order to ensure
+this is the case, all Sparkplug Edge Nodes and Sparkplug Host Applications need an accurate
+mechanism for ensuring their clocks remain accurate. This is typically left to the system operating
+system using technologies such as Network Time Protocol (NTP). Regardless of the mechanism used,
+ensuring all timestamps are accurate and in UTC is critical to Sparkplug operations.
+
+[[operational_behavior_timestamp_resolution]]
+==== Timestamp Resolution
+
+Sparkplug timestamps are denominated in nanoseconds so that data acquired at high rates can be
+ordered and correlated at the resolution at which it was actually sampled.
+
+* [tck-testable tck-id-timestamps-nanoseconds]#[yellow-background]*[tck-id-timestamps-nanoseconds] Every
+Sparkplug timestamp MUST be expressed as the number of nanoseconds elapsed since epoch (Jan 1, 1970)
+in UTC.*#
+** This applies to the payload timestamp, to the timestamp of an individual Metric, to the timestamp
+in a Sparkplug Host Application's STATE message, and to any value of the DateTime datatype.
+** Non-normative comment: nanosecond denomination is a property of the encoding and does not require
+an implementation to have a nanosecond resolution time source. An implementation whose time source
+is coarser than one nanosecond expresses its timestamps in nanoseconds all the same, scaled to that
+denomination. For example, an implementation whose time source has a resolution of one millisecond
+expresses a timestamp as the number of milliseconds since epoch multiplied by 1000000.
+** Non-normative comment: an unsigned 64-bit integer of nanoseconds since epoch covers a range of
+approximately 584 years, reaching the year 2554. Implementers should note that this range is only
+available to a genuinely unsigned representation. The Google Protocol Buffers uint64 type is
+represented as a signed 64-bit long in Java, and several widely used nanosecond time representations
+are signed 64-bit as well, which reduces the reachable range to approximately 292 years, ending on
+2262-04-11. This is the practical ceiling for such implementations.
+
+Non-normative comment: the resolution of a timestamp is not the same as its accuracy. Denominating a
+timestamp in nanoseconds says how finely a value can be expressed, not how closely it corresponds to
+true time. The accuracy that can be achieved depends on the time source. Network Time Protocol
+typically synchronizes to within a few milliseconds over a local network, which is coarser than the
+resolution of the encoding, while Global Positioning System receivers and the Precision Time
+Protocol can achieve considerably better. A consuming application should not infer the accuracy of a
+timestamp from the resolution at which it is expressed, and an application that requires timestamps
+to be comparable across Edge Nodes at better than the accuracy of its time synchronization mechanism
+needs to address that outside of Sparkplug.
 
 [[operational_behavior_case_sensitivity]]
 === Case Sensitivity in Sparkplug

--- a/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
+++ b/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc
@@ -390,7 +390,7 @@ A simple Sparkplug B payload with values would be represented as follows:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "seq": 2,
                 "bd_seq": 0,
                 "descriptor_seq": 1,
@@ -400,7 +400,7 @@ A simple Sparkplug B payload with values would be represented as follows:
                 "metrics": [{
                         "name": "My Metric",
                         "alias": 1,
-                        "timestamp": 1479123452194,
+                        "timestamp": 1479123452194000000,
                         "dataType": "String",
                         "value": "Test"
                 }]
@@ -1570,7 +1570,7 @@ Consider the following Sparkplug B payload in the NBIRTH message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "definition_id": "9f2c...e2",
                 "seq": 0,
                 "descriptor_seq": 0,
@@ -1579,39 +1579,39 @@ Consider the following Sparkplug B payload in the NBIRTH message shown above:
         "content": {
                 "metrics": [{
                         "name": "Node Control/Reboot",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Node Control/Rebirth",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Node Control/Next Server",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Node Control/Scan Rate",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 3000
                 }, {
                         "name": "Properties/Hardware Make",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "Acme"
                 }, {
                         "name": "Properties/Hardware Model",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "EdgeGate 2000"
                 }, {
                         "name": "Properties/OS",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "Linux"
                 }, {
                         "name": "Properties/OS Version",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "6.1"
                 }, {
                         "name": "Supply Voltage",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 12.1
                 }]
         }
@@ -1694,7 +1694,7 @@ Consider the following Sparkplug B payload in the NREBIRTH message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "definition_id": "9f2c...e2",
                 "seq": 0,
                 "descriptor_seq": 4,
@@ -1703,39 +1703,39 @@ Consider the following Sparkplug B payload in the NREBIRTH message shown above:
         "content": {
                 "metrics": [{
                         "name": "Node Control/Reboot",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Node Control/Rebirth",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Node Control/Next Server",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Node Control/Scan Rate",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 3000
                 }, {
                         "name": "Properties/Hardware Make",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "Acme"
                 }, {
                         "name": "Properties/Hardware Model",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "EdgeGate 2000"
                 }, {
                         "name": "Properties/OS",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "Linux"
                 }, {
                         "name": "Properties/OS Version",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "6.1"
                 }, {
                         "name": "Supply Voltage",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 12.1
                 }]
         }
@@ -1799,7 +1799,7 @@ Consider the following Sparkplug B payload in the DBIRTH message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "definition_id": "a1c9...77",
                 "seq": 1,
                 "descriptor_seq": 0,
@@ -1808,39 +1808,39 @@ Consider the following Sparkplug B payload in the DBIRTH message shown above:
         "content": {
                 "metrics": [{
                         "name": "Running",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Faulted",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Speed",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 0
                 }, {
                         "name": "Fill/Setpoint",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 500.0
                 }, {
                         "name": "Fill/Actual",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 0.0
                 }, {
                         "name": "Temperature",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 21.5
                 }, {
                         "name": "Motor/Run",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Motor/Speed Setpoint",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 0
                 }, {
                         "name": "Properties/Manufacturer",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "Acme"
                 }]
         }
@@ -1902,7 +1902,7 @@ Consider the following Sparkplug B payload in the DREBIRTH message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "definition_id": "a1c9...77",
                 "seq": 1,
                 "descriptor_seq": 4,
@@ -1911,39 +1911,39 @@ Consider the following Sparkplug B payload in the DREBIRTH message shown above:
         "content": {
                 "metrics": [{
                         "name": "Running",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Faulted",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Speed",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 0
                 }, {
                         "name": "Fill/Setpoint",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 500.0
                 }, {
                         "name": "Fill/Actual",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 0.0
                 }, {
                         "name": "Temperature",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 21.5
                 }, {
                         "name": "Motor/Run",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": false
                 }, {
                         "name": "Motor/Speed Setpoint",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 0
                 }, {
                         "name": "Properties/Manufacturer",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": "Acme"
                 }]
         }
@@ -2004,7 +2004,7 @@ Consider the following Sparkplug B payload in the NDATA message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122847913,
                 "definition_id": "9f2c...e2",
                 "seq": 2,
                 "descriptor_seq": 1,
@@ -2013,7 +2013,7 @@ Consider the following Sparkplug B payload in the NDATA message shown above:
         "content": {
                 "metrics": [{
                         "name": "Supply Voltage",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122847913,
                         "value": 12.3
                 }]
         }
@@ -2068,7 +2068,7 @@ Consider the following Sparkplug B payload in the DDATA message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "definition_id": "a1c9...77",
                 "seq": 0,
                 "descriptor_seq": 1,
@@ -2077,11 +2077,11 @@ Consider the following Sparkplug B payload in the DDATA message shown above:
         "content": {
                 "metrics": [{
                         "name": "Running",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": true
                 }, {
                         "name": "Speed",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "value": 120
                 }]
         }
@@ -2124,7 +2124,7 @@ Consider the following Sparkplug B payload in the REBIRTH message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "source" : "IamHost"
         }
 }
@@ -2173,13 +2173,13 @@ Consider the following Sparkplug B payload in the NCMD message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "source": "IamHost"
         },
         "content": {
                 "metrics": [{
                         "name": "DIGITAL_OUT_1",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "dataType": "Boolean",
                         "value": true
                 }]
@@ -2204,13 +2204,13 @@ The following is a representation of an NCMD payload that invokes the 'Calibrate
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "source": "IamHost"
         },
         "content": {
                 "metrics": [{
                         "name": "Calibrate",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "dataType": "Command",
                         "command": {
                                 "correlation_id": "5d7c1f6e-9c2a-4f1b-8f3a-1c9d2e6b4a01",
@@ -2268,18 +2268,18 @@ Consider the following Sparkplug B payload in the DCMD message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "source": "IamHost"
         },
         "content": {
                 "metrics": [{
                         "name": "Motor/Run",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "dataType": "Boolean",
                         "value": true
                 }, {
                         "name": "Motor/Speed Setpoint",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "dataType": "Int32",
                         "value": 120
                 }]
@@ -2330,7 +2330,7 @@ Consider the following Sparkplug B payload in the NRESP message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "seq": 3,
                 "descriptor_seq": 2,
                 "bd_seq": 0
@@ -2338,7 +2338,7 @@ Consider the following Sparkplug B payload in the NRESP message shown above:
         "content": {
                 "metrics": [{
                         "name": "Calibrate",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "dataType": "Command",
                         "command": {
                                 "correlation_id": "5d7c1f6e-9c2a-4f1b-8f3a-1c9d2e6b4a01",
@@ -2394,7 +2394,7 @@ Consider the following Sparkplug B payload in the DRESP message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "seq": 4,
                 "descriptor_seq": 2,
                 "bd_seq": 0
@@ -2402,7 +2402,7 @@ Consider the following Sparkplug B payload in the DRESP message shown above:
         "content": {
                 "metrics": [{
                         "name": "Reset",
-                        "timestamp": 1486144502122,
+                        "timestamp": 1486144502122000000,
                         "dataType": "Command",
                         "command": {
                                 "correlation_id": "a1b2c3d4-0001",
@@ -2488,7 +2488,7 @@ Consider the following Sparkplug B payload in the NDEATH message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "bd_seq": 0
         }
 }
@@ -2531,7 +2531,7 @@ Consider the following Sparkplug B payload in the DDEATH message shown above:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122000000,
                 "seq": 123,
                 "descriptor_seq": 3,
                 "bd_seq": 0
@@ -2656,7 +2656,7 @@ spCv4.0/STATE/my_host_application
 ----
 {
         "online": true,
-        "timestamp": 1486144502122,
+        "timestamp": 1486144502122000000,
         "bd_seq": 12,
         "client_id": "my_host_application_client_1"
 }
@@ -2668,7 +2668,7 @@ packet carries the same timestamp, the same bd_seq number, and the same client_i
 ----
 {
         "online": false,
-        "timestamp": 1486144502122,
+        "timestamp": 1486144502122000000,
         "bd_seq": 12,
         "client_id": "my_host_application_client_1"
 }
@@ -2731,7 +2731,7 @@ of the serialized Content:
 ----
 {
         "header": {
-                "timestamp": 1486144502122,
+                "timestamp": 1486144502122847913,
                 "definition_id": "9f2c...e2",
                 "seq": 2,
                 "descriptor_seq": 1,


### PR DESCRIPTION
Closes #232.

Per the spec team decision on the issue — no diff option for timestamps, nanosecond resolution added.

The unit was already nanoseconds in the Chapter 6 field descriptions, but **no tagged assertion covered
it anywhere** (`payloads-timestamp-in-UTC` covers UTC only), and nothing addressed resolution at all.

### New section: Timestamp Resolution (Ch. 5)

- `tck-id-timestamps-nanoseconds` — every Sparkplug timestamp MUST be nanoseconds since epoch in UTC.
  Stated once as the authoritative requirement, and listed as applying to the payload timestamp, Metric
  timestamps, the STATE timestamp, and DateTime values.
- Non-normative note that nanosecond denomination is a property of the encoding and does not require a
  nanosecond time source — an implementation with a coarser clock scales up, so a millisecond-resolution
  device publishes `ms × 1000000`. Without this, "support nanoseconds" reads as requiring a nanosecond
  clock, which almost nothing has.
- Non-normative note on range: an unsigned 64-bit nanosecond count reaches 2554, but only for a
  genuinely unsigned representation. Protobuf's `uint64` is a signed `long` in Java, and several widely
  used nanosecond time representations are signed 64-bit as well, which caps the reachable range at
  **2262-04-11**. That is the practical ceiling for Tahu and for anything storing timestamps in an
  int64.
- Non-normative note separating **resolution from accuracy**, which is what the Dec 2024 exchange on
  the issue was about: NTP typically synchronizes to a few milliseconds — coarser than the encoding —
  while GPS and PTP do better, so a consumer should not infer accuracy from resolution.

Also removed the bare lowercase "must" from the existing Timestamps prose, which duplicated a tagged
assertion.

### Bug this surfaced

**All 64 example timestamp values were stale millisecond-era numbers.** `1486144502122` reads as
2017-02-03 as milliseconds, but under the nanosecond requirement it is **1970-01-01 00:24:46** — 24
minutes after epoch. They survived the ms→ns migration untouched, so every worked example in the
chapter contradicted the spec.

Rescaled by ×10⁶, which preserves the original dates exactly (2017-02-03 and 2016-11-14) and keeps the
distinction between the payload timestamp and the deliberately-earlier metric timestamp in the generic
example. The NDATA example — and its compressed counterpart — now carries genuine sub-millisecond
digits (`1486144502122847913`) so at least one worked example exercises the resolution the issue is
about. The remaining values end in six zeros, which now illustrates the scaling rule rather than being
an error.

### Notes for reviewers

- **1 tck-id added, none removed.** `tck/requirements.py` needs a re-run against a rebuilt
  `specification/build/tck-audit.xml`.
- Not rendered; `specification/gradlew` is missing its wrapper jar. Verified by inspection: all
  `link:#` anchors resolve, every tck-id appears exactly twice, all 18 example payloads parse as JSON.

### Not addressed

- No delta or diff encoding, per the spec team decision.
- Nanosecond denomination costs +3 bytes per timestamp versus milliseconds (9-byte varint vs 6). Not
  changed here; if message size becomes a concern it is a separate discussion now that the diff option
  is off the table.
